### PR TITLE
Heroicons v2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^8.0|^8.1"
+        "php": "^8.0|^8.1",
+        "blade-ui-kit/blade-heroicons": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/resources/views/cart/coupon.blade.php
+++ b/resources/views/cart/coupon.blade.php
@@ -18,7 +18,7 @@
                 </div>
                 <div v-if="cart.discount_name && cart.discount_amount < 0" class="text-ct-inactive mt-1 flex items-center gap-x-2">
                     <button v-on:click="removeCoupon">
-                        <x-heroicon-s-x class="h-4 w-4" />
+                        <x-heroicon-s-x-mark class="h-4 w-4" />
                     </button>
                     @lang('Discount'): @{{ cart.discount_name }}
                 </div>

--- a/resources/views/checkout/partials/address-cards-popup.blade.php
+++ b/resources/views/checkout/partials/address-cards-popup.blade.php
@@ -4,7 +4,7 @@
         <x-rapidez-ct::card.inactive>
             <x-rapidez-ct::title class="mb-5">@lang('My addresses')</x-rapidez-ct::title>
             <label class="absolute cursor-pointer top-7 right-7 w-5 h-5" for="popup">
-                <x-heroicon-o-x/>
+                <x-heroicon-o-x-mark/>
             </label>
 
             <div class="grid sm:grid-cols-2 gap-5">


### PR DESCRIPTION
In https://github.com/rapidez/core/pull/304, I updated Heroicons to version 2. In the update, some icons have changed, so this should also be updated in the rapidez/checkout-theme package.