### PR TITLE
Change shipping to be shown excluding tax for parity with checkout summary

### DIFF
--- a/resources/views/cart/partials/sidebar/summary.blade.php
+++ b/resources/views/cart/partials/sidebar/summary.blade.php
@@ -7,18 +7,18 @@
             <span>@lang('Subtotal')</span>
             <span>@{{ cart.subtotal | price }}</span>
         </li>
-        <li v-if="cart.tax > 0">
-            <span>@lang('Tax')</span>
-            <span>@{{ cart.tax | price }}</span>
-        </li>
         <li>
             <span>@lang('Shipping')</span>
-            <span v-if="cart.shipping_amount > 0">
-                @{{ cart.shipping_amount | price }}
+            <span v-if="cart.shipping_amount_excl_tax > 0">
+                @{{ cart.shipping_amount_excl_tax | price }}
             </span>
             <span v-else class="font-medium text-ct-enhanced">
                 @lang('Free')
             </span>
+        </li>
+        <li v-if="cart.tax > 0">
+            <span>@lang('Tax')</span>
+            <span>@{{ cart.tax | price }}</span>
         </li>
         <li v-if="cart.discount_name">
             <span>@lang('Discount') (@{{ cart.discount_name }})</span>


### PR DESCRIPTION
also moved it to be above tax so that it makes sense