### PR TITLE
Use a named slot to separate attribute merges

### DIFF
--- a/resources/views/checkout/partials/sections/payment.blade.php
+++ b/resources/views/checkout/partials/sections/payment.blade.php
@@ -8,7 +8,7 @@
                 v-model="checkout.payment_method"
                 required
             >
-                <x-slot:wrapper class="min-h-[40px]">
+                <x-slot:slot class="min-h-[40px]">
                     <div>@{{ method.title }}</div>
                     <img
                         class="max-h-10"
@@ -16,7 +16,7 @@
                         v-bind:src="`/vendor/payment-icons/${method.code}.svg`"
                         onerror="this.onerror=null; this.src='/vendor/payment-icons/creditcard.svg'"
                     />
-                </x-slot:wrapper>
+                </x-slot:slot>
             </x-rapidez-ct::input.radio>
         </div>
         <graphql query="{ checkoutAgreements { agreement_id name checkbox_text content is_html mode } }">

--- a/resources/views/checkout/partials/sections/payment.blade.php
+++ b/resources/views/checkout/partials/sections/payment.blade.php
@@ -2,20 +2,21 @@
     <form id="payment" class="flex flex-col gap-2" v-on:submit.prevent="save(['payment_method'], 4)">
         <div v-for="(method, index) in checkout.payment_methods">
             <x-rapidez-ct::input.radio
-                class="min-h-[40px]"
                 name="payment_method"
                 v-bind:value="method.code"
                 v-bind:dusk="'method-'+index"
                 v-model="checkout.payment_method"
                 required
             >
-                <div>@{{ method.title }}</div>
-                <img
-                    class="max-h-10"
-                    v-bind:alt="method.code"
-                    v-bind:src="`/vendor/payment-icons/${method.code}.svg`"
-                    onerror="this.onerror=null; this.src='/vendor/payment-icons/creditcard.svg'"
-                />
+                <x-slot:wrapper class="min-h-[40px]">
+                    <div>@{{ method.title }}</div>
+                    <img
+                        class="max-h-10"
+                        v-bind:alt="method.code"
+                        v-bind:src="`/vendor/payment-icons/${method.code}.svg`"
+                        onerror="this.onerror=null; this.src='/vendor/payment-icons/creditcard.svg'"
+                    />
+                </x-slot:wrapper>
             </x-rapidez-ct::input.radio>
         </div>
         <graphql query="{ checkoutAgreements { agreement_id name checkbox_text content is_html mode } }">

--- a/resources/views/components/input/radio.blade.php
+++ b/resources/views/components/input/radio.blade.php
@@ -1,12 +1,14 @@
-<label {{ $attributes->only('class')->class("relative flex w-full cursor-pointer items-center justify-start gap-x-3 rounded border bg-white p-2 py-5 sm:p-7 text-sm text-ct-primary") }}>
+@slots(['wrapper'])
+
+<label {{ $wrapper->attributes->merge(['class' => 'relative flex w-full cursor-pointer items-center justify-start gap-x-3 rounded border bg-white p-2 py-5 sm:p-7 text-sm text-ct-primary']) }}>
     {{-- The 0 opacity and 1px width ensures the element is "visible" for the browser so the browser can focus which is useful for validation --}}
-    <input type="radio" {{ $attributes->except('class')->merge(['class' => 'peer opacity-0 border-0 w-px']) }}/>
+    <input type="radio" {{ $attributes->class(['peer opacity-0 border-0 w-px']) }}/>
     <div class="absolute -inset-y-px -left-px w-1 rounded-l bg-ct-accent opacity-0 transition-all peer-checked:opacity-100"></div>
     {{-- TODO: Check if we can't just style the radio? --}}
     <div class="relative aspect-square w-6 shrink-0 rounded-full border bg-white transition-all after:absolute after:inset-1 after:rounded-full after:bg-ct-accent after:opacity-0 after:transition-all after:peer-checked:opacity-100 peer-disabled:bg-ct-inactive-100"></div>
-    @isset($slot)
+    @if(!$wrapper->isEmpty() || isset($slot))
         <div class="flex w-full flex-wrap items-center justify-between gap-x-3">
-            {{ $slot }}
+            {{ $wrapper->isEmpty() ? $slot : $wrapper }}
         </div>
-    @endisset
+    @endif
 </label>

--- a/resources/views/components/input/radio.blade.php
+++ b/resources/views/components/input/radio.blade.php
@@ -1,12 +1,12 @@
 @slots(['wrapper'])
 
-<label {{ $wrapper->attributes->merge(['class' => 'relative flex w-full cursor-pointer items-center justify-start gap-x-3 rounded border bg-white p-2 py-5 sm:p-7 text-sm text-ct-primary']) }}>
+<label {{ ($slot->attributes ?? $wrapper->attributes)->merge(['class' => 'relative flex w-full cursor-pointer items-center justify-start gap-x-3 rounded border bg-white p-2 py-5 sm:p-7 text-sm text-ct-primary']) }}>
     {{-- The 0 opacity and 1px width ensures the element is "visible" for the browser so the browser can focus which is useful for validation --}}
     <input type="radio" {{ $attributes->class(['peer opacity-0 border-0 w-px']) }}/>
     <div class="absolute -inset-y-px -left-px w-1 rounded-l bg-ct-accent opacity-0 transition-all peer-checked:opacity-100"></div>
     {{-- TODO: Check if we can't just style the radio? --}}
     <div class="relative aspect-square w-6 shrink-0 rounded-full border bg-white transition-all after:absolute after:inset-1 after:rounded-full after:bg-ct-accent after:opacity-0 after:transition-all after:peer-checked:opacity-100 peer-disabled:bg-ct-inactive-100"></div>
     <div class="flex w-full flex-wrap items-center justify-between gap-x-3">
-        {!! $wrapper->toHtml() ?: $slot !!}
+        {{ $wrapper }}{{ $slot }}
     </div>
 </label>

--- a/resources/views/components/input/radio.blade.php
+++ b/resources/views/components/input/radio.blade.php
@@ -6,9 +6,7 @@
     <div class="absolute -inset-y-px -left-px w-1 rounded-l bg-ct-accent opacity-0 transition-all peer-checked:opacity-100"></div>
     {{-- TODO: Check if we can't just style the radio? --}}
     <div class="relative aspect-square w-6 shrink-0 rounded-full border bg-white transition-all after:absolute after:inset-1 after:rounded-full after:bg-ct-accent after:opacity-0 after:transition-all after:peer-checked:opacity-100 peer-disabled:bg-ct-inactive-100"></div>
-    @if(!$wrapper->isEmpty() || isset($slot))
-        <div class="flex w-full flex-wrap items-center justify-between gap-x-3">
-            {{ $wrapper->isEmpty() ? $slot : $wrapper }}
-        </div>
-    @endif
+    <div class="flex w-full flex-wrap items-center justify-between gap-x-3">
+        {!! $wrapper->toHtml() ?: $slot !!}
+    </div>
 </label>


### PR DESCRIPTION
Follow-up to https://github.com/rapidez/checkout-theme/pull/23

This update lets us do magics like this:

```blade
<x-rapidez-ct::input.radio v-model="some_variable">
    <x-slot:wrapper class="font-bold">
        label text
    </x-slot:wrapper>
</x-rapidez-ct::input.radio>
```

Of course, you can still do:

```blade
<x-rapidez-ct::input.radio v-model="some_variable">
    label text
</x-rapidez-ct::input.radio>
```

or even:

```blade
<x-rapidez-ct::input.radio v-model="some_variable">
    <x-slot:wrapper class="font-bold"></x-slot:wrapper>
    label text
</x-rapidez-ct::input.radio>
```

This seems like the nicest approach to me.