### PR TITLE
Checkout success fixes

### DIFF
--- a/resources/js/components/AddressCard.vue
+++ b/resources/js/components/AddressCard.vue
@@ -4,24 +4,29 @@
             address: Object,
             shipping: Boolean,
             billing: Boolean,
+            customTitle: {
+                type: String,
+                default: '',
+            }
         },
 
         render() {
-            return this.$scopedSlots.default({
-                address: this.formattedAddress,
-                baseAddress: this.address,
-                shipping: this.shipping,
-                billing: this.billing,
-                isEmpty: this.isEmpty,
-            });
+            return this.$scopedSlots.default(Object.assign(this, { self: this }))
         },
 
         computed: {
             formattedAddress() {
+                let street = this.address.street
+                if (Array.isArray(street)) {
+                    street = street?.filter(Boolean).join(' ') ?? ''
+                } else {
+                    street = street.replace('\n', ' ')
+                }
+
                 let data = {
                     company: this.address.company ?? '',
                     name: [this.address.firstname, this.address.middlename, this.address.lastname].filter(Boolean).join(' '),
-                    street: this.address.street?.filter(Boolean).join(' ') ?? '',
+                    street: street,
                     city: [this.address.postcode, this.address.city].filter(Boolean).join(' '),
                     country: this.address.country_id ?? this.address.country_code ?? '',
                 }

--- a/resources/js/components/AddressCard.vue
+++ b/resources/js/components/AddressCard.vue
@@ -15,26 +15,33 @@
         },
 
         computed: {
-            formattedAddress() {
+            company() {
+                return this.address.company ?? '';
+            },
+
+            street() {
                 let street = this.address.street
                 if (Array.isArray(street)) {
-                    street = street?.filter(Boolean).join(' ') ?? ''
+                    return street?.filter(Boolean).join(' ') ?? ''
                 } else {
-                    street = street.replace('\n', ' ')
+                    return street.replace('\n', ' ')
                 }
+            },
 
-                let data = {
-                    company: this.address.company ?? '',
-                    name: [this.address.firstname, this.address.middlename, this.address.lastname].filter(Boolean).join(' '),
-                    street: street,
-                    city: [this.address.postcode, this.address.city].filter(Boolean).join(' '),
-                    country: this.address.country_id ?? this.address.country_code ?? '',
-                }
-                return Object.fromEntries(Object.entries(data).filter(([key, value]) => value))
+            name() {
+                return [this.address.firstname, this.address.middlename, this.address.lastname].filter(Boolean).join(' ');
+            },
+
+            city() {
+                return [this.address.postcode, this.address.city].filter(Boolean).join(' ')
+            },
+
+            country() {
+                return this.address.country_id ?? this.address.country_code ?? ''
             },
 
             isEmpty() {
-                return Object.keys(this.formattedAddress).filter(key => key != 'country').length == 0
+                return [this.company, this.street, this.name, this.city].filter(Boolean).length == 0
             }
         }
     }

--- a/resources/js/components/AddressCard.vue
+++ b/resources/js/components/AddressCard.vue
@@ -4,10 +4,6 @@
             address: Object,
             shipping: Boolean,
             billing: Boolean,
-            customTitle: {
-                type: String,
-                default: '',
-            }
         },
 
         render() {

--- a/resources/js/components/CheckoutSuccessAddresses.vue
+++ b/resources/js/components/CheckoutSuccessAddresses.vue
@@ -27,34 +27,36 @@
         },
 
         computed: {
-            addresses() {
+            hideBilling() {
+                return this.shipping && this.billing && this.sameAddress(this.shipping, this.billing);
+            },
+
+            shipping() {
                 if(!this.order?.sales_order_addresses) {
-                    return {}
+                    return null;
                 }
-                let addresses = {}
 
                 let shipping = this.order.sales_order_addresses.filter(e => e.address_type == 'shipping')
-                let billing = this.order.sales_order_addresses.filter(e => e.address_type == 'billing')
-
-                let pickup_address = shipping.length > 1 ? shipping[0] : null;
-                let same_billing = this.sameAddress(shipping.at(-1), billing.at(-1))
-
-                if(pickup_address) {
-                    addresses['pickup'] = pickup_address
-                    addresses['billing'] = billing.at(-1)
-                    return addresses
-                }
-
-                if(!same_billing) {
-                    addresses['shipping'] = shipping.at(-1)
-                    addresses['billing'] = billing.at(-1)
-                    return addresses
-                }
-                
-                addresses['shipping_billing'] = shipping.at(-1)
-
-                return addresses
+                return shipping.length > 1 ? null : shipping.at(-1)
             },
+
+            billing() {
+                if(!this.order?.sales_order_addresses) {
+                    return null;
+                }
+
+                let billing = this.order.sales_order_addresses.filter(e => e.address_type == 'billing')
+                return billing.at(-1)
+            },
+
+            pickup() {
+                if(!this.order?.sales_order_addresses) {
+                    return null;
+                }
+
+                let shipping = this.order.sales_order_addresses.filter(e => e.address_type == 'shipping')
+                return shipping.length > 1 ? shipping[0] : null
+            }
         }
     }
 </script>

--- a/resources/js/components/CheckoutSuccessAddresses.vue
+++ b/resources/js/components/CheckoutSuccessAddresses.vue
@@ -1,0 +1,60 @@
+<script>
+    export default {
+        props: {
+            order: Object,
+        },
+
+        render() {
+            return this.$scopedSlots.default(Object.assign(this, { self: this }))
+        },
+
+        methods: {
+            serialize(address) {
+                return JSON.stringify({
+                    firstname: address.firstname ?? '',
+                    lastname: address.lastname ?? '', 
+                    postcode: address.postcode ?? '',
+                    street: address.street ?? '',
+                    city: address.city ?? '',
+                    country_id: address.country_id ?? '',
+                    telephone: address.telephone ?? '',
+                })
+            },
+
+            sameAddress(a1, a2) {
+                return this.serialize(a1) == this.serialize(a2)
+            },
+        },
+
+        computed: {
+            addresses() {
+                if(!this.order?.sales_order_addresses) {
+                    return {}
+                }
+                let addresses = {}
+
+                let shipping = this.order.sales_order_addresses.filter(e => e.address_type == 'shipping')
+                let billing = this.order.sales_order_addresses.filter(e => e.address_type == 'billing')
+
+                let pickup_address = shipping.length > 1 ? shipping[0] : null;
+                let same_billing = this.sameAddress(shipping.at(-1), billing.at(-1))
+
+                if(pickup_address) {
+                    addresses['pickup'] = pickup_address
+                    addresses['billing'] = billing.at(-1)
+                    return addresses
+                }
+
+                if(!same_billing) {
+                    addresses['shipping'] = shipping.at(-1)
+                    addresses['billing'] = billing.at(-1)
+                    return addresses
+                }
+                
+                addresses['shipping_billing'] = shipping.at(-1)
+
+                return addresses
+            },
+        }
+    }
+</script>

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -1,4 +1,5 @@
 Vue.component('checkout-address', () => import('./components/CheckoutAddress.vue'))
+Vue.component('checkout-success-addresses', () => import('./components/CheckoutSuccessAddresses.vue'))
 Vue.component('address-card', () => import('./components/AddressCard.vue'))
 
 Vue.mixin({

--- a/resources/views/checkout/partials/sections/success/order-info.blade.php
+++ b/resources/views/checkout/partials/sections/success/order-info.blade.php
@@ -1,16 +1,13 @@
 <x-rapidez-ct::card.inactive>
     <div class="flex flex-wrap -space-x-px max-sm:-space-y-px">
         <checkout-success-addresses :order="order">
-            <div slot-scope="{ addresses }" class="flex flex-1 flex-col -space-y-px">
-                <template v-for="address, key in addresses">
-                    <x-rapidez-ct::card.address
-                        v-bind:address="address"
-                        v-bind:shipping="key.includes('shipping')"
-                        v-bind:billing="key.includes('billing')"
-                        v-bind:custom-title="key.includes('pickup') ? '{{ __('Pickup address') }}' : ''"
-                        check
-                    />
+            <div slot-scope="{ hideBilling, shipping, billing, pickup }" class="flex flex-1 flex-col -space-y-px">
+                <template v-if="hideBilling">
+                    <x-rapidez-ct::card.address v-bind:address="shipping" shipping billing check/>
                 </template>
+                <x-rapidez-ct::card.address v-bind:address="pickup" custom-title="Pickup address" check/>
+                <x-rapidez-ct::card.address v-if="!hideBilling && shipping" v-bind:address="shipping" shipping check/>
+                <x-rapidez-ct::card.address v-if="!hideBilling && billing" v-bind:address="billing" billing check/>
             </div>
         </checkout-success-addresses>
         <div class="flex flex-1 flex-col -space-y-px">

--- a/resources/views/checkout/partials/sections/success/order-info.blade.php
+++ b/resources/views/checkout/partials/sections/success/order-info.blade.php
@@ -1,14 +1,18 @@
 <x-rapidez-ct::card.inactive>
     <div class="flex flex-wrap -space-x-px max-sm:-space-y-px">
-        <div class="flex flex-1 flex-col -space-y-px">
-            <template v-if="checkout.hide_billing || (checkout.shipping_address?.customer_address_id == checkout.billing_address?.customer_address_id && checkout.shipping_address?.customer_address_id)">
-                <x-rapidez-ct::card.address v-bind:address="checkout.shipping_address" shipping billing check/>
-            </template>
-            <template v-else>
-                <x-rapidez-ct::card.address v-bind:address="checkout.shipping_address" shipping check/>
-                <x-rapidez-ct::card.address v-bind:address="checkout.billing_address" billing check/>
-            </template>
-        </div>
+        <checkout-success-addresses :order="order">
+            <div slot-scope="{ addresses }" class="flex flex-1 flex-col -space-y-px">
+                <template v-for="address, key in addresses">
+                    <x-rapidez-ct::card.address
+                        v-bind:address="address"
+                        v-bind:shipping="key.includes('shipping')"
+                        v-bind:billing="key.includes('billing')"
+                        v-bind:custom-title="key.includes('pickup') ? '{{ __('Pickup address') }}' : ''"
+                        check
+                    />
+                </template>
+            </div>
+        </checkout-success-addresses>
         <div class="flex flex-1 flex-col -space-y-px">
             <x-rapidez-ct::card.white class="flex-1" check>
                 <x-rapidez-ct::title.lg class="mb-4 pr-8">

--- a/resources/views/components/address.blade.php
+++ b/resources/views/components/address.blade.php
@@ -4,7 +4,7 @@
     {{ $attributes->whereStartsWith('v-') }}
     @if (!$attributes->has('v-bind:shipping')) :shipping="{{ var_export($shipping) }}" @endif
     @if (!$attributes->has('v-bind:billing')) :billing="{{ var_export($billing) }}" @endif
-    v-slot="{ formattedAddress, billing, shipping, isEmpty, customTitle }"
+    v-slot="{ company, name, street, city, country, billing, shipping, isEmpty, customTitle }"
 >
     <div v-if="!isEmpty" {{ $attributes->whereDoesntStartWith('v-')->class('flex flex-col') }}>
         @if ($check)
@@ -22,9 +22,11 @@
         </x-rapidez-ct::title.lg>
         <div class="flex flex-1 flex-wrap justify-between">
             <ul class="flex flex-col gap-1">
-                <li v-for="data in formattedAddress">
-                    @{{ data }}
-                </li>
+                <li v-if="company">@{{ company }}</li>
+                <li v-if="name">@{{ name }}</li>
+                <li v-if="street">@{{ street }}</li>
+                <li v-if="city">@{{ city }}</li>
+                <li v-if="country">@{{ country }}</li>
             </ul>
             @if (!empty($slot))
                 <div class="mt-auto flex flex-col self-end">

--- a/resources/views/components/address.blade.php
+++ b/resources/views/components/address.blade.php
@@ -4,7 +4,7 @@
     {{ $attributes->whereStartsWith('v-') }}
     @if (!$attributes->has('v-bind:shipping')) :shipping="{{ var_export($shipping) }}" @endif
     @if (!$attributes->has('v-bind:billing')) :billing="{{ var_export($billing) }}" @endif
-    v-slot="{ address, billing, shipping, isEmpty }"
+    v-slot="{ formattedAddress, billing, shipping, isEmpty, customTitle }"
 >
     <div v-if="!isEmpty" {{ $attributes->whereDoesntStartWith('v-')->class('flex flex-col') }}>
         @if ($check)
@@ -14,14 +14,15 @@
             </template>
         @endif
         <x-rapidez-ct::title.lg class="mb-4 pr-8">
-            <template v-if="billing && shipping">@lang('Shipping & billing address')</template>
+            <template v-if="customTitle">@{{ customTitle }}</template>
+            <template v-else-if="billing && shipping">@lang('Shipping & billing address')</template>
             <template v-else-if="shipping">@lang('Shipping address')</template>
             <template v-else-if="billing">@lang('Billing address')</template>
             <template v-else>@lang('Address')</template>
         </x-rapidez-ct::title.lg>
         <div class="flex flex-1 flex-wrap justify-between">
             <ul class="flex flex-col gap-1">
-                <li v-for="data in address">
+                <li v-for="data in formattedAddress">
                     @{{ data }}
                 </li>
             </ul>

--- a/resources/views/components/address.blade.php
+++ b/resources/views/components/address.blade.php
@@ -1,4 +1,4 @@
-@props(['shipping' => false, 'billing' => false, 'check' => false])
+@props(['shipping' => false, 'billing' => false, 'check' => false, 'customTitle' => null])
 
 <address-card
     {{ $attributes->whereStartsWith('v-') }}
@@ -14,11 +14,14 @@
             </template>
         @endif
         <x-rapidez-ct::title.lg class="mb-4 pr-8">
-            <template v-if="customTitle">@{{ customTitle }}</template>
-            <template v-else-if="billing && shipping">@lang('Shipping & billing address')</template>
-            <template v-else-if="shipping">@lang('Shipping address')</template>
-            <template v-else-if="billing">@lang('Billing address')</template>
-            <template v-else>@lang('Address')</template>
+            @if($customTitle)
+                @lang($customTitle)
+            @else
+                <template v-if="billing && shipping">@lang('Shipping & billing address')</template>
+                <template v-else-if="shipping">@lang('Shipping address')</template>
+                <template v-else-if="billing">@lang('Billing address')</template>
+                <template v-else>@lang('Address')</template>
+            @endif
         </x-rapidez-ct::title.lg>
         <div class="flex flex-1 flex-wrap justify-between">
             <ul class="flex flex-col gap-1">

--- a/resources/views/components/card/address.blade.php
+++ b/resources/views/components/card/address.blade.php
@@ -1,4 +1,4 @@
-<x-rapidez-ct::card.white>
+<x-rapidez-ct::card.white {{ $attributes->only('v-if') }}>
     <x-rapidez-ct::address {{ $attributes }}>
         {{ $slot }}
     </x-rapidez-ct::address>

--- a/resources/views/components/card/address.blade.php
+++ b/resources/views/components/card/address.blade.php
@@ -1,5 +1,7 @@
+@props(['customTitle' => null])
+
 <x-rapidez-ct::card.white {{ $attributes->only('v-if') }}>
-    <x-rapidez-ct::address {{ $attributes }}>
+    <x-rapidez-ct::address {{ $attributes }} :$customTitle>
         {{ $slot }}
     </x-rapidez-ct::address>
 </x-rapidez-ct::card.white>


### PR DESCRIPTION
Address card:
- Allow custom titles
- Allow street to be a string (e.g. as retrieved from the `sales_order_address` table)

Checkout success:
- Grab addresses from order instead of from checkout component
- If there is more than 1 shipping addresses, assume the first one is a pickup location
- Format appropriately, clean up template with loop