### PR TITLE
Update hide_billing to be set correctly

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -5,7 +5,7 @@ Vue.mixin({
     computed: {
         billingAndShippingAreTheSame() {
             if (this.$root.checkout.shipping_address?.customer_address_id) {
-                return this.$root.checkout.shipping_address?.customer_address_id == this.$root.checkout.billing_address?.customer_address_id
+                this.$root.checkout.hide_billing = this.$root.checkout.shipping_address?.customer_address_id == this.$root.checkout.billing_address?.customer_address_id
             }
 
             return this.$root.checkout.hide_billing


### PR DESCRIPTION
There might be a cleaner way to do this? The need for this update shows me that we really need to fix the hide_billing variable instead of working around it like this.

This is necessary, by the way, because the rapidez checkout assumes when hide_billing is true that billingAddress is equal to shippingAddress, even when this might not be the case.