### PR TITLE
Fix text-inactive missing -ct-, add icon width

### DIFF
--- a/resources/views/account/partials/orders.blade.php
+++ b/resources/views/account/partials/orders.blade.php
@@ -13,7 +13,7 @@
                                 @lang('Number of products')
                                 (@{{ order.items.length }})
                             </span>
-                            <span class="text-inactive">
+                            <span class="text-ct-inactive">
                                 @lang('Total price'): @{{ order.total.grand_total.value | price }}
                                 /
                                 @lang('Order date'): @{{ (new Date(order.order_date)).toLocaleDateString() }}

--- a/resources/views/components/dashboard/item/index.blade.php
+++ b/resources/views/components/dashboard/item/index.blade.php
@@ -5,7 +5,7 @@
     'is' => isset($item['href']) ? 'a' : 'button',
 ]) }}>
     @if ($item['icon'] ?? false)
-        <x-icon name="{{ $item['icon'] }}" class="h-6 stroke-[1.5px]"/>
+        <x-icon name="{{ $item['icon'] }}" class="h-6 w-6 stroke-[1.5px]"/>
     @endif
     <div class="flex flex-col gap-y-1">
         @if ($item['heading'] ?? false)
@@ -21,7 +21,7 @@
             </strong>
         @endif
         @if ($item['subheading'] ?? false)
-            <p class="text-inactive">
+            <p class="text-ct-inactive">
                 @lang($item['subheading'])
             </p>
         @endif

--- a/resources/views/components/input/label.blade.php
+++ b/resources/views/components/input/label.blade.php
@@ -1,5 +1,5 @@
 @props(['required' => false])
-<div class="text-inactive">
+<div class="text-ct-inactive">
     {{ $slot }}
     @if ($required)
         <span>*</span>


### PR DESCRIPTION
Icon width is necessary so that it doesn't cause inconsistent widths when the icons themselves aren't square. Heroicons are all square, but not all `x-icon` icons have to be :)