### PR TITLE
Split up to more blade files to make override easier

### DIFF
--- a/resources/views/checkout/partials/sections/payment.blade.php
+++ b/resources/views/checkout/partials/sections/payment.blade.php
@@ -1,22 +1,7 @@
 <x-rapidez-ct::card.inactive>
     <form id="payment" class="flex flex-col gap-2" v-on:submit.prevent="save(['payment_method'], 4)">
         <div v-for="(method, index) in checkout.payment_methods">
-            <x-rapidez-ct::input.radio
-                class="min-h-[40px]"
-                name="payment_method"
-                v-bind:value="method.code"
-                v-bind:dusk="'method-'+index"
-                v-model="checkout.payment_method"
-                required
-            >
-                <div>@{{ method.title }}</div>
-                <img
-                    class="max-h-10"
-                    v-bind:alt="method.code"
-                    v-bind:src="`/vendor/payment-icons/${method.code}.svg`"
-                    onerror="this.onerror=null; this.src='/vendor/payment-icons/creditcard.svg'"
-                />
-            </x-rapidez-ct::input.radio>
+            @include('rapidez-ct::checkout.sections.partials.payment.payment-methods')
         </div>
         <graphql query="{ checkoutAgreements { agreement_id name checkbox_text content is_html mode } }">
             <div v-if="data?.checkoutAgreements?.length" class="mt-5 flex flex-col gap-y-4" slot-scope="{ data }">
@@ -29,17 +14,7 @@
                         @{{ agreement.checkbox_text }}
                     </label>
                     <template v-else>
-                        <x-rapidez-ct::input.checkbox
-                            name="agreement_ids[]"
-                            v-bind:value="agreement.agreement_id"
-                            v-model="checkout.agreement_ids"
-                            dusk="agreements"
-                            required
-                        >
-                            <label class="text-ct-primary cursor-pointer text-sm underline" v-bind:for="agreement.checkbox_text">
-                                @{{ agreement.checkbox_text }}
-                            </label>
-                        </x-rapidez-ct::input.checkbox>
+                        @include('rapidez-ct::checkout.sections.partials.payment.agreement-checkbox')
                     </template>
                     <x-rapidez-ct::slideover id="agreement.checkbox_text">
                         <x-slot name="title">

--- a/resources/views/checkout/partials/sections/payment/agreement-checkbox.blade.php
+++ b/resources/views/checkout/partials/sections/payment/agreement-checkbox.blade.php
@@ -1,0 +1,11 @@
+<x-rapidez-ct::input.checkbox
+    name="agreement_ids[]"
+    v-bind:value="agreement.agreement_id"
+    v-model="checkout.agreement_ids"
+    dusk="agreements"
+    required
+>
+    <label class="text-ct-primary cursor-pointer text-sm underline" v-bind:for="agreement.checkbox_text">
+        @{{ agreement.checkbox_text }}
+    </label>
+</x-rapidez-ct::input.checkbox>

--- a/resources/views/checkout/partials/sections/payment/payment-methods.blade.php
+++ b/resources/views/checkout/partials/sections/payment/payment-methods.blade.php
@@ -1,0 +1,15 @@
+<x-rapidez-ct::input.radio
+    name="payment_method"
+    v-bind:value="method.code"
+    v-bind:dusk="'method-'+index"
+    v-model="checkout.payment_method"
+    required
+>
+    <div>@{{ method.title }}</div>
+    <img
+        class="max-h-10"
+        v-bind:alt="method.code"
+        v-bind:src="`/vendor/payment-icons/${method.code}.svg`"
+        onerror="this.onerror=null; this.src='/vendor/payment-icons/creditcard.svg'"
+    />
+</x-rapidez-ct::input.radio>

--- a/resources/views/checkout/partials/sections/success/create-account-title.blade.php
+++ b/resources/views/checkout/partials/sections/success/create-account-title.blade.php
@@ -1,0 +1,3 @@
+<x-rapidez-ct::title.lg>
+    @lang('Create account')
+</x-rapidez-ct::title.lg>

--- a/resources/views/checkout/partials/sections/success/create-account.blade.php
+++ b/resources/views/checkout/partials/sections/success/create-account.blade.php
@@ -1,7 +1,5 @@
 <x-rapidez-ct::card.inactive v-if="!$root.loggedIn">
-    <x-rapidez-ct::title.lg>
-        @lang('Create account')
-    </x-rapidez-ct::title.lg>
+    @include('rapidez-ct::checkout.partials.sections.success.create-account-title')
     <graphql-mutation
         v-cloak
         query="mutation customer ($firstname: String!, $lastname: String!, $email: String!, $password: String) { createCustomerV2 ( input: { firstname: $firstname, lastname: $lastname, email: $email, password: $password } ) { customer { email } } }"
@@ -41,10 +39,5 @@
     </graphql-mutation>
 </x-rapidez-ct::card.inactive>
 <x-rapidez-ct::card.inactive v-else>
-    <x-rapidez-ct::title.lg>
-        @lang('Already logged in')
-    </x-rapidez-ct::title.lg>
-    <x-rapidez-ct::button.enhanced class="mt-5" href="{{ route('account.overview') }}">
-        @lang('Go to your account')
-    </x-rapidez-ct::button.enhanced>
+    @include('rapidez-ct::checkout.partials.sections.success.logged-in')
 </x-rapidez-ct::card.inactive>

--- a/resources/views/checkout/partials/sections/success/logged-in.blade.php
+++ b/resources/views/checkout/partials/sections/success/logged-in.blade.php
@@ -1,0 +1,6 @@
+<x-rapidez-ct::title.lg>
+    @lang('Already logged in')
+</x-rapidez-ct::title.lg>
+<x-rapidez-ct::button.enhanced class="mt-5" href="{{ route('account.overview') }}">
+    @lang('Go to your account')
+</x-rapidez-ct::button.enhanced>


### PR DESCRIPTION
If we have to change something in payment.blade for example the payment methods we had to override the entire file. I moved some items to there own files to make override easier for small parts in the payment and success page step. 