### PR TITLE
Only show title in account center if it exists

### DIFF
--- a/resources/views/account/partials/layout.blade.php
+++ b/resources/views/account/partials/layout.blade.php
@@ -16,9 +16,11 @@
         <template v-if="loggedIn">
             <x-rapidez-ct::layout>
                 <x-rapidez-ct::toolbar>
-                    <x-rapidez-ct::title :href="$backurl">
-                        @yield('title')
-                    </x-rapidez-ct::title>
+                    @hasSection('title')
+                        <x-rapidez-ct::title :href="$backurl">
+                            @yield('title')
+                        </x-rapidez-ct::title>
+                    @endif
                     @yield('button')
                 </x-rapidez-ct::toolbar>
                 @yield('account-content')


### PR DESCRIPTION
This is relevant for, for example, multiple wishlists, where you can't really use the title section.