### PR TITLE
Add newsletter to checkout & splice up cart products listing into separate parts

### DIFF
--- a/resources/views/cart/partials/product/description.blade.php
+++ b/resources/views/cart/partials/product/description.blade.php
@@ -1,0 +1,16 @@
+<td class="flex max-md:w-1/2 md:table-cell">
+    <div class="flex flex-col items-start">
+        <a :href="item.url | url">
+            <div dusk="cart-item-name">@{{ item.name }}</div>
+            <div v-for="(optionValue, option) in item.options">
+                @{{ option }}: @{{ optionValue }}
+            </div>
+            <div v-for="option in cart?.items2?.find((item) => item.item_id == itemId).options.filter((option) => !['info_buyRequest', 'option_ids'].includes(option.code) && option.label)">
+                @{{ option.label }}: @{{ option.value.title || option.value }}
+            </div>
+        </a>
+        <button v-on:click="remove(item)" class="text-ct-inactive mt-1 text-xs hover:underline" :dusk="'item-delete-' + index">
+            @lang('Remove')
+        </button>
+    </div>
+</td>

--- a/resources/views/cart/partials/product/description.blade.php
+++ b/resources/views/cart/partials/product/description.blade.php
@@ -9,8 +9,6 @@
                 @{{ option.label }}: @{{ option.value.title || option.value }}
             </div>
         </a>
-        <button v-on:click="remove(item)" class="text-ct-inactive mt-1 text-xs hover:underline" :dusk="'item-delete-' + index">
-            @lang('Remove')
-        </button>
+        @include('rapidez-ct::cart.partials.product.remove-button')
     </div>
 </td>

--- a/resources/views/cart/partials/product/image.blade.php
+++ b/resources/views/cart/partials/product/image.blade.php
@@ -1,0 +1,4 @@
+<td class="h-24 w-40 !pl-0 max-md:flex max-md:w-1/2">
+    <img v-if="item.image" class="object-contain" :alt="item.name" :src="'/storage/{{ config('rapidez.store') }}/resizes/200/magento/catalog/product' + item.image + '.webp'">
+    <x-rapidez::no-image v-else />
+</td>

--- a/resources/views/cart/partials/product/price.blade.php
+++ b/resources/views/cart/partials/product/price.blade.php
@@ -1,0 +1,14 @@
+<td class="flex items-center font-medium max-md:w-1/3 md:table-cell">
+    <div v-if="item.specialPrice">
+        @{{ item.specialPrice | price }}
+    </div>
+    <div :class="{ 'line-through text-xs text-ct-inactive font-normal': item.specialPrice }">
+        @{{ item.price | price }}
+    </div>
+</td>
+<td class="flex items-center font-medium max-md:w-1/3 md:table-cell [&>*]:mx-auto">
+    <x-rapidez-ct::input.quantity/>
+</td>
+<td class="flex items-center justify-end text-right font-medium max-md:w-1/3 md:table-cell">
+    @{{ item.total | price }}
+</td>

--- a/resources/views/cart/partials/product/remove-button.blade.php
+++ b/resources/views/cart/partials/product/remove-button.blade.php
@@ -1,0 +1,3 @@
+<button v-on:click="remove(item)" class="text-ct-inactive mt-1 text-xs hover:underline" :dusk="'item-delete-' + index">
+    @lang('Remove')
+</button>

--- a/resources/views/cart/partials/products.blade.php
+++ b/resources/views/cart/partials/products.blade.php
@@ -10,40 +10,9 @@
     </thead>
     <tbody class="divide-y">
         <tr v-for="(item, itemId, index) in cart.items" class="flex flex-wrap gap-y-5 py-5 md:table-row md:[&>*]:p-5">
-            <td class="h-24 w-40 !pl-0 max-md:flex max-md:w-1/2">
-                <img v-if="item.image" class="object-contain" :alt="item.name" :src="'/storage/{{ config('rapidez.store') }}/resizes/200/magento/catalog/product' + item.image + '.webp'">
-                <x-rapidez::no-image v-else />
-            </td>
-            <td class="flex max-md:w-1/2 md:table-cell">
-                <div class="flex flex-col items-start">
-                    <a :href="item.url | url">
-                        <div dusk="cart-item-name">@{{ item.name }}</div>
-                        <div v-for="(optionValue, option) in item.options">
-                            @{{ option }}: @{{ optionValue }}
-                        </div>
-                        <div v-for="option in cart?.items2?.find((item) => item.item_id == itemId).options.filter((option) => !['info_buyRequest', 'option_ids'].includes(option.code) && option.label)">
-                            @{{ option.label }}: @{{ option.value.title || option.value }}
-                        </div>
-                    </a>
-                    <button v-on:click="remove(item)" class="text-ct-inactive mt-1 text-xs hover:underline" :dusk="'item-delete-' + index">
-                        @lang('Remove')
-                    </button>
-                </div>
-            </td>
-            <td class="flex items-center font-medium max-md:w-1/3 md:table-cell">
-                <div v-if="item.specialPrice">
-                    @{{ item.specialPrice | price }}
-                </div>
-                <div :class="{ 'line-through text-xs text-ct-inactive font-normal': item.specialPrice }">
-                    @{{ item.price | price }}
-                </div>
-            </td>
-            <td class="flex items-center font-medium max-md:w-1/3 md:table-cell [&>*]:mx-auto">
-                <x-rapidez-ct::input.quantity/>
-            </td>
-            <td class="flex items-center justify-end text-right font-medium max-md:w-1/3 md:table-cell">
-                @{{ item.total | price }}
-            </td>
+            @include('rapidez-ct::cart.partials.product.image')
+            @include('rapidez-ct::cart.partials.product.description')
+            @include('rapidez-ct::cart.partials.product.price')
         </tr>
     </tbody>
 </table>

--- a/resources/views/checkout/partials/sections/newsletter.blade.php
+++ b/resources/views/checkout/partials/sections/newsletter.blade.php
@@ -1,0 +1,1 @@
+<x-rapidez-ct::newsletter v-model="checkout.newsletter_subscribe" />

--- a/resources/views/checkout/steps/credentials.blade.php
+++ b/resources/views/checkout/steps/credentials.blade.php
@@ -6,6 +6,7 @@
     <x-rapidez-ct::sections>
         @include('rapidez-ct::checkout.partials.sections.login')
         @include('rapidez-ct::checkout.partials.sections.address')
+        @include('rapidez-ct::checkout.partials.sections.newsletter')
         @include('rapidez-ct::checkout.partials.sections.shipping')
     </x-rapidez-ct::sections>
 </form>


### PR DESCRIPTION
Splitting up the cart items like this allows for more easily overwriting only the stuff that is necessary, say you want to slightly change the styling of the item description in your implementation.