### PR TITLE
[2.x] Split templates up like in 1.x

### DIFF
--- a/resources/views/cart/cart.blade.php
+++ b/resources/views/cart/cart.blade.php
@@ -1,6 +1,4 @@
-<x-rapidez-ct::title-progress-bar>
-    @lang('Cart')
-</x-rapidez-ct::title-progress-bar>
+@include('rapidez-ct::cart.partials.cart-title')
 
 <x-rapidez-ct::sections>
     @include('rapidez-ct::cart.partials.products')

--- a/resources/views/cart/content.blade.php
+++ b/resources/views/cart/content.blade.php
@@ -1,0 +1,7 @@
+<x-rapidez-ct::layout>
+    @include('rapidez-ct::cart.cart')
+    <x-slot:sidebar>
+        @include('rapidez-ct::cart.partials.sidebar.sidebar')
+    </x-slot:sidebar>
+</x-rapidez-ct::layout>
+@include('rapidez-ct::cart.partials.crosssells')

--- a/resources/views/cart/coupon.blade.php
+++ b/resources/views/cart/coupon.blade.php
@@ -1,47 +1,7 @@
 <toggler>
     <div slot-scope="{ isOpen, toggle }">
         <div v-if="isOpen" v-cloak class="text-sm">
-            <graphql-mutation
-                :query="'mutation ($cart_id: String!, $coupon_code: String!) { applyCouponToCart(input: { cart_id: $cart_id, coupon_code: $coupon_code }) { cart { ' + config.queries.cart + ' } } }'"
-                :variables="{ cart_id: mask, coupon_code: '' }"
-                :notify="{ message: config.translations.cart.coupon.applied }"
-                :clear="true"
-                :watch="false"
-                :callback="updateCart"
-                :error-callback="checkResponseForExpiredCart"
-                v-slot="{ mutate, variables }"
-            >
-                <form v-on:submit.prevent="mutate" class="flex w-full gap-x-3">
-                    <x-rapidez::input
-                        :label="false"
-                        class="text-ct-primary w-60"
-                        name="couponCode"
-                        placeholder="Coupon code"
-                        v-model="variables.coupon_code"
-                        v-bind:disabled="$root.loading"
-                        required
-                    />
-                    <x-rapidez::button type="submit" class="sm:text-sm">
-                        @lang('Apply')
-                    </x-rapidez::button>
-                </form>
-            </graphql-mutation>
-
-            <div class="flex w-full gap-x-3">
-                <x-rapidez-ct::input
-                    class="text-ct-primary w-60"
-                    name="couponCode"
-                    :placeholder="__('Enter code') . '...'"
-                    v-on="inputEvents"
-                    v-bind:value="couponCode"
-                    v-bind:disabled="$root.loading"
-                    required
-                />
-                <x-rapidez-ct::button.outline type="submit" loader>
-                    @lang('Apply')
-                </x-rapidez-ct::button.outline>
-            </div>
-
+            <x-rapidez-ct::coupon-field />
             <template v-if="cart.applied_coupons?.length" v-for="coupon in cart.applied_coupons" v-cloak>
                 <graphql-mutation
                     :query="'mutation ($cart_id: String!) { removeCouponFromCart(input: { cart_id: $cart_id }) { cart { ' + config.queries.cart + ' } } }'"

--- a/resources/views/cart/overview.blade.php
+++ b/resources/views/cart/overview.blade.php
@@ -13,13 +13,7 @@
     >
     </graphql>
     <div v-if="hasCart" v-cloak class="container">
-        <x-rapidez-ct::layout class="!mt-0">
-            @include('rapidez-ct::cart.cart')
-            <x-slot:sidebar>
-                @include('rapidez-ct::cart.partials.sidebar.sidebar')
-            </x-slot:sidebar>
-        </x-rapidez-ct::layout>
-        @include('rapidez-ct::cart.partials.crosssells')
+        @include('rapidez-ct::cart.content')
     </div>
     <div v-else class="container">
         <p>@lang("You don't have anything in your cart.")</p>

--- a/resources/views/cart/partials/cart-title.blade.php
+++ b/resources/views/cart/partials/cart-title.blade.php
@@ -1,0 +1,3 @@
+<x-rapidez-ct::title-progress-bar>
+    @lang('Cart')
+</x-rapidez-ct::title-progress-bar>

--- a/resources/views/cart/partials/products.blade.php
+++ b/resources/views/cart/partials/products.blade.php
@@ -1,5 +1,5 @@
 <table class="w-full border-b">
-    <thead class="bg-ct-inactive-100 mt-5 flex rounded md:table-header-group">
+    <thead class="bg-ct-inactive-100 flex rounded md:table-header-group">
         <tr class="text-xs *:py-4 *:font-normal *:px-5">
             <th class="!pl-0 max-md:hidden"></th>
             <th class="text-start">@lang('Product')</th>

--- a/resources/views/components/coupon-field.blade.php
+++ b/resources/views/components/coupon-field.blade.php
@@ -1,0 +1,40 @@
+<graphql-mutation
+    :query="'mutation ($cart_id: String!, $coupon_code: String!) { applyCouponToCart(input: { cart_id: $cart_id, coupon_code: $coupon_code }) { cart { ' + config.queries.cart + ' } } }'"
+    :variables="{ cart_id: mask, coupon_code: '' }"
+    :notify="{ message: config.translations.cart.coupon.applied }"
+    :clear="true"
+    :watch="false"
+    :callback="updateCart"
+    :error-callback="checkResponseForExpiredCart"
+    v-slot="{ mutate, variables }"
+>
+    <form v-on:submit.prevent="mutate" class="flex w-full gap-x-3">
+        <x-rapidez::input
+            :label="false"
+            class="text-ct-primary w-60"
+            name="couponCode"
+            placeholder="Coupon code"
+            v-model="variables.coupon_code"
+            v-bind:disabled="$root.loading"
+            required
+        />
+        <x-rapidez::button type="submit" class="sm:text-sm">
+            @lang('Apply')
+        </x-rapidez::button>
+    </form>
+</graphql-mutation>
+
+<div class="flex w-full gap-x-3">
+    <x-rapidez-ct::input
+        class="text-ct-primary w-60"
+        name="couponCode"
+        :placeholder="__('Enter code') . '...'"
+        v-on="inputEvents"
+        v-bind:value="couponCode"
+        v-bind:disabled="$root.loading"
+        required
+    />
+    <x-rapidez-ct::button.outline type="submit" loader>
+        @lang('Apply')
+    </x-rapidez-ct::button.outline>
+</div>

--- a/resources/views/components/sections/index.blade.php
+++ b/resources/views/components/sections/index.blade.php
@@ -1,3 +1,3 @@
-<div {{ $attributes->class('space-y-[2px] mt-5 mb-6') }}>
+<div {{ $attributes->class('space-y-0.5 mt-5 mb-6') }}>
     {{ $slot }}
 </div>

--- a/resources/views/components/title/index.blade.php
+++ b/resources/views/components/title/index.blade.php
@@ -1,3 +1,3 @@
-<x-rapidez-ct::title.base {{ $attributes->class('text-2xl') }}>
+<x-rapidez-ct::title.base {{ $attributes->class('text-2xl text-ct-neutral') }}>
     {{ $slot }}
 </x-rapidez-ct::title.base>


### PR DESCRIPTION
Copied from #67 

Seems like this update (and only this update) was missed in the upgrade to 2.x because they happened around the same time. Very helpful to have this changed for the upgrade of confira to 2.x