### PR TITLE
[2.x] Remove extra coupon field

### DIFF
--- a/resources/views/components/coupon-field.blade.php
+++ b/resources/views/components/coupon-field.blade.php
@@ -23,18 +23,3 @@
         </x-rapidez::button>
     </form>
 </graphql-mutation>
-
-<div class="flex w-full gap-x-3">
-    <x-rapidez-ct::input
-        class="text-ct-primary w-60"
-        name="couponCode"
-        :placeholder="__('Enter code') . '...'"
-        v-on="inputEvents"
-        v-bind:value="couponCode"
-        v-bind:disabled="$root.loading"
-        required
-    />
-    <x-rapidez-ct::button.outline type="submit" loader>
-        @lang('Apply')
-    </x-rapidez-ct::button.outline>
-</div>


### PR DESCRIPTION
This extra field seems to have been a remnant of the 1.x -> 2.x upgrade, possibly a merge conflict.