### PR TITLE
[2.x] Rapidez v2 compatibility

### DIFF
--- a/resources/views/checkout/partials/layout.blade.php
+++ b/resources/views/checkout/partials/layout.blade.php
@@ -1,5 +1,5 @@
 <x-rapidez-ct::layout class="mt-8 sm:mt-14">
-    <template v-if="checkout.step == 2 && hasItems">
+    <template v-if="checkout.step == 2 && $root.cart?.total_quantity">
         @include('rapidez-ct::checkout.steps.credentials')
     </template>
 


### PR DESCRIPTION
The checkout as it stands does not work in Rapidez 2 and you get a blank page. Rapidez 2 does not have the `cart` component anymore and thus doesn't use this `hasItems` variable.