### PR TITLE
Fix the newsletter subscribe to not mutate right away

### DIFF
--- a/resources/views/components/newsletter/index.blade.php
+++ b/resources/views/components/newsletter/index.blade.php
@@ -18,6 +18,7 @@
 
     <x-rapidez-ct::newsletter.partials.checkbox
         :v-model="$attributes->has('v-model') ? $attributes['v-model'] : 'variables.is_subscribed'"
+        :isPartOfAnotherForm="$attributes->has('v-model')"
         :$id
     />
 

--- a/resources/views/components/newsletter/partials/checkbox.blade.php
+++ b/resources/views/components/newsletter/partials/checkbox.blade.php
@@ -1,11 +1,12 @@
+@props(['isPartOfAnotherForm', 'id'])
+
 <x-rapidez-ct::input.checkbox :attributes="$attributes->merge([
     'class' => 'relative flex w-full cursor-pointer !items-start rounded border bg-white p-7',
     'id' => $id,
-    'v-on:change'  => '() => {
-        if (typeof mutate === \'function\') { mutate() }
+])" v-on:change="() => {
+        if (typeof mutate === 'function' && (!{{ $isPartOfAnotherForm }})) { mutate() }
         if ($root.loggedIn) { $root.user.extension_attributes.is_subscribed=variables.is_subscribed }
-    }'
-])">
+    }">
     <x-slot:slot class="ml-2 flex flex-col gap-1">
         <span class="text-ct-primary text-sm font-medium">@lang('Yes, I want to subscribe to the newsletter')</span>
         <span class="text-ct-inactive text-xs font-normal">@lang('You will receive this newsletter approximately 2x a year')</span>


### PR DESCRIPTION
The way this work(ed) was if you check the checkbox on the registration form, it would send the graphql request right away instead of subscribing the customer in the register(createCustomer) request so it's linked. Now it does go in one request.