### PR TITLE
[2.x] Move card outside of include to reduce need for overwrites

### DIFF
--- a/resources/views/checkout/partials/sections/payment.blade.php
+++ b/resources/views/checkout/partials/sections/payment.blade.php
@@ -1,30 +1,28 @@
-<x-rapidez-ct::card.inactive>
-    <form id="payment" class="flex flex-col gap-2" v-on:submit.prevent="save(['payment_method'], 4)">
-        <div v-for="(method, index) in checkout.payment_methods">
-            @include('rapidez-ct::checkout.partials.sections.payment.payment-methods')
-        </div>
-        <graphql query="{ checkoutAgreements { agreement_id name checkbox_text content is_html mode } }">
-            <div v-if="data?.checkoutAgreements?.length" class="mt-5 flex flex-col gap-y-4" slot-scope="{ data }">
-                <div v-for="agreement in data.checkoutAgreements">
-                    <label
-                        class="text-ct-primary cursor-pointer text-sm underline"
-                        v-bind:for="agreement.checkbox_text"
-                        v-if="agreement.mode == 'AUTO'"
-                    >
-                        @{{ agreement.checkbox_text }}
-                    </label>
-                    <template v-else>
-                        @include('rapidez-ct::checkout.partials.sections.payment.agreement-checkbox')
-                    </template>
-                    <x-rapidez-ct::slideover id="agreement.checkbox_text">
-                        <x-slot name="title">
-                            @{{ agreement.name }}
-                        </x-slot>
-                        <div v-if="agreement.is_html" v-html="agreement.content"></div>
-                        <div v-else class="whitespace-pre-wrap" v-text="agreement.content"></div>
-                    </x-rapidez-ct::slideover>
-                </div>
+<form id="payment" class="flex flex-col gap-2" v-on:submit.prevent="save(['payment_method'], 4)">
+    <div v-for="(method, index) in checkout.payment_methods">
+        @include('rapidez-ct::checkout.partials.sections.payment.payment-methods')
+    </div>
+    <graphql query="{ checkoutAgreements { agreement_id name checkbox_text content is_html mode } }">
+        <div v-if="data?.checkoutAgreements?.length" class="mt-5 flex flex-col gap-y-4" slot-scope="{ data }">
+            <div v-for="agreement in data.checkoutAgreements">
+                <label
+                    class="text-ct-primary cursor-pointer text-sm underline"
+                    v-bind:for="agreement.checkbox_text"
+                    v-if="agreement.mode == 'AUTO'"
+                >
+                    @{{ agreement.checkbox_text }}
+                </label>
+                <template v-else>
+                    @include('rapidez-ct::checkout.partials.sections.payment.agreement-checkbox')
+                </template>
+                <x-rapidez-ct::slideover id="agreement.checkbox_text">
+                    <x-slot name="title">
+                        @{{ agreement.name }}
+                    </x-slot>
+                    <div v-if="agreement.is_html" v-html="agreement.content"></div>
+                    <div v-else class="whitespace-pre-wrap" v-text="agreement.content"></div>
+                </x-rapidez-ct::slideover>
             </div>
-        </graphql>
-    </form>
-</x-rapidez-ct::card.inactive>
+        </div>
+    </graphql>
+</form>

--- a/resources/views/checkout/steps/payment.blade.php
+++ b/resources/views/checkout/steps/payment.blade.php
@@ -3,7 +3,9 @@
 </x-rapidez-ct::title-progress-bar>
 
 <x-rapidez-ct::sections>
-    @include('rapidez-ct::checkout.partials.sections.payment')
+    <x-rapidez-ct::card.inactive>
+        @include('rapidez-ct::checkout.partials.sections.payment')
+    </x-rapidez-ct::card.inactive>
 </x-rapidez-ct::sections>
 
 <x-rapidez-ct::toolbar>


### PR DESCRIPTION
Adding anything into this card required overwriting a file with a bunch of functionality unnecessarily. By moving the card outside of the include we can limit the need for that, keeping it to a simpler file to overwrite.