### PR TITLE
disable graphql cache of order view

### DIFF
--- a/resources/views/account/order.blade.php
+++ b/resources/views/account/order.blade.php
@@ -20,7 +20,6 @@
     <graphql
         query='@include('rapidez::account.partials.queries.order')'
         check="customer.orders.items[0]"
-        cache="orderdetail{{ $id }}"
     >
         <div v-if="data" slot-scope="{ data }">
             <x-rapidez-ct::sections>


### PR DESCRIPTION
This currently gives problems with viewing the order when changes have been made. For example order status progression is not directly visible without clearing the localeStorage.