### PR TITLE
Fix newsletter in checkout success for logged in customers

### DIFF
--- a/resources/views/account/partials/sections/edit/newsletter.blade.php
+++ b/resources/views/account/partials/sections/edit/newsletter.blade.php
@@ -1,1 +1,1 @@
-<x-rapidez-ct::newsletter/>
+<x-rapidez-ct::newsletter has-data/>

--- a/resources/views/components/newsletter/index.blade.php
+++ b/resources/views/components/newsletter/index.blade.php
@@ -1,4 +1,4 @@
-@props(['id' => uniqId('newsletter-')])
+@props(['id' => uniqId('newsletter-'), 'hasData' => false])
 
 <x-rapidez-ct::card.inactive>
     <x-rapidez-ct::title.lg class="mb-5">
@@ -6,19 +6,23 @@
     </x-rapidez-ct::title.lg>
 
     @if (!$attributes->has('v-model'))
+        @php
+            $subscribedData = $hasData
+                ? 'data?.customer?.is_subscribed ?? $root.user?.extension_attributes?.is_subscribed ?? false'
+                : '$root.user?.extension_attributes?.is_subscribed ?? false'
+        @endphp
         <graphql-mutation
             v-cloak
             query="mutation subscribeNewsletter ($is_subscribed: Boolean!) { updateCustomerV2(input: { is_subscribed: $is_subscribed }) { customer { is_subscribed } } }"
             :alert="false"
             :clear="false"
-            :variables="{ is_subscribed: data?.customer?.is_subscribed ?? $root.user?.extension_attributes?.is_subscribed ?? false }"
+            :variables="{ is_subscribed: {{ $subscribedData }} }"
             v-slot="{ mutate, variables }"
         >
     @endif
 
     <x-rapidez-ct::newsletter.partials.checkbox
         :v-model="$attributes->has('v-model') ? $attributes['v-model'] : 'variables.is_subscribed'"
-        :isPartOfAnotherForm="$attributes->has('v-model')"
         :$id
     />
 


### PR DESCRIPTION
`data` is undefined when it's not wrapped in a component that has `data` available and there doesn't seem to be a good way to check for undefined-ness in this particular context. This then consequently throws an error and breaks the whole checkout success.