### PR TITLE
[2.x] Add default to isPartOfAnotherForm prop

### DIFF
--- a/resources/views/components/newsletter/partials/checkbox.blade.php
+++ b/resources/views/components/newsletter/partials/checkbox.blade.php
@@ -1,4 +1,4 @@
-@props(['isPartOfAnotherForm', 'id'])
+@props(['isPartOfAnotherForm' => false, 'id'])
 
 <x-rapidez-ct::input.checkbox :attributes="$attributes->merge([
     'class' => 'relative flex w-full cursor-pointer !items-start rounded border bg-white p-7',


### PR DESCRIPTION
This ended up giving a 500 error on the account register page and possibly others. We can just assume it's false when not defined.