### PR TITLE
[2.x] Override account layout partial

### DIFF
--- a/resources/core-overwrites/account/partials/layout.blade.php
+++ b/resources/core-overwrites/account/partials/layout.blade.php
@@ -1,0 +1,1 @@
+@include('rapidez-ct::account.partials.layout')


### PR DESCRIPTION
Some packages that add to the account center (like `rapidez/multiple-wishlists`) will try to use the default core layout, causing them to have the wrong layout.