### PR TITLE
Fix address popup when list is to long | Fix text alignment

### DIFF
--- a/resources/views/account/partials/address-cards-popup.blade.php
+++ b/resources/views/account/partials/address-cards-popup.blade.php
@@ -1,5 +1,5 @@
 <x-rapidez-ct::popup title="My addresses">
-    <div class="grid sm:grid-cols-2 gap-5">
+    <div class="grid gap-5 lg:grid-cols-2">
         <template v-for="userAddress, addressIndex in data.customer.addresses">
             <graphql-mutation
                 query="mutation address($id: Int!, $default_billing: Boolean, $default_shipping: Boolean){ updateCustomerAddress ( id: $id, input: {default_billing: $default_billing, default_shipping: $default_shipping} ) { id } }"

--- a/resources/views/checkout/partials/address-card.blade.php
+++ b/resources/views/checkout/partials/address-card.blade.php
@@ -1,4 +1,4 @@
-<div class="grid sm:grid-cols-2 gap-5">
+<div class="grid gap-5 lg:grid-cols-2">
     <template v-for="userAddress in $root.user.addresses">
         <x-rapidez-ct::card.address
             v-bind:key="userAddress.id"

--- a/resources/views/checkout/partials/address-cards-popup.blade.php
+++ b/resources/views/checkout/partials/address-cards-popup.blade.php
@@ -1,7 +1,7 @@
 <input type="checkbox" id="popup" class="peer hidden"/>
-<div class="fixed inset-0 opacity-0 transition z-50 flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto">
-    <x-rapidez-ct::sections class="relative z-10">
-        <x-rapidez-ct::card.inactive class="max-h-dvh overflow-y-auto scrollbar-hide relative xl:max-h-[calc(100dvh-44px)]">
+<div class="fixed inset-0 opacity-0 transition z-50 max-h-full flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto">
+    <x-rapidez-ct::sections class="relative z-10 max-h-full overflow-y-auto scrollbar-hide">
+        <x-rapidez-ct::card.inactive>
             <x-rapidez-ct::title class="mb-5">@lang('My addresses')</x-rapidez-ct::title>
             <label class="absolute cursor-pointer top-7 right-7 w-5 h-5" for="popup">
                 <x-heroicon-o-x-mark/>

--- a/resources/views/checkout/partials/address-cards-popup.blade.php
+++ b/resources/views/checkout/partials/address-cards-popup.blade.php
@@ -1,5 +1,5 @@
 <input type="checkbox" id="popup" class="peer hidden"/>
-<div class="fixed inset-0 opacity-0 transition z-50 max-h-full flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto lg:py-5">
+<div class="fixed inset-0 opacity-0 transition z-50 flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto lg:py-5">
     <x-rapidez-ct::sections class="relative z-10 max-h-full overflow-y-auto scrollbar-hide">
         <x-rapidez-ct::card.inactive>
             <x-rapidez-ct::title class="mb-5">@lang('My addresses')</x-rapidez-ct::title>

--- a/resources/views/checkout/partials/address-cards-popup.blade.php
+++ b/resources/views/checkout/partials/address-cards-popup.blade.php
@@ -1,5 +1,5 @@
 <input type="checkbox" id="popup" class="peer hidden"/>
-<div class="fixed inset-0 opacity-0 transition z-50 max-h-full flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto">
+<div class="fixed inset-0 opacity-0 transition z-50 max-h-full flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto lg:py-5">
     <x-rapidez-ct::sections class="relative z-10 max-h-full overflow-y-auto scrollbar-hide">
         <x-rapidez-ct::card.inactive>
             <x-rapidez-ct::title class="mb-5">@lang('My addresses')</x-rapidez-ct::title>

--- a/resources/views/checkout/partials/address-cards-popup.blade.php
+++ b/resources/views/checkout/partials/address-cards-popup.blade.php
@@ -1,7 +1,7 @@
 <input type="checkbox" id="popup" class="peer hidden"/>
 <div class="fixed inset-0 opacity-0 transition z-50 flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto">
     <x-rapidez-ct::sections class="relative z-10">
-        <x-rapidez-ct::card.inactive>
+        <x-rapidez-ct::card.inactive class="max-h-dvh overflow-y-auto scrollbar-hide relative xl:max-h-[calc(100dvh-44px)]">
             <x-rapidez-ct::title class="mb-5">@lang('My addresses')</x-rapidez-ct::title>
             <label class="absolute cursor-pointer top-7 right-7 w-5 h-5" for="popup">
                 <x-heroicon-o-x-mark/>

--- a/resources/views/checkout/partials/address-cards-popup.blade.php
+++ b/resources/views/checkout/partials/address-cards-popup.blade.php
@@ -1,13 +1,3 @@
-<input type="checkbox" id="popup" class="peer hidden"/>
-<div class="fixed inset-0 opacity-0 transition z-50 flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto lg:py-5">
-    <x-rapidez-ct::sections class="relative z-10 max-h-full overflow-y-auto scrollbar-hide">
-        <x-rapidez-ct::card.inactive>
-            <x-rapidez-ct::title class="mb-5">@lang('My addresses')</x-rapidez-ct::title>
-            <label class="absolute cursor-pointer top-7 right-7 w-5 h-5" for="popup">
-                <x-heroicon-o-x-mark/>
-            </label>
-            @include('rapidez-ct::checkout.partials.address-card')
-        </x-rapidez-ct::card.inactive>
-    </x-rapidez-ct::sections>
-    <label class="absolute cursor-pointer inset-0 bg-ct-primary/60" for="popup"></label>
-</div>
+<x-rapidez-ct::popup title="My addresses">
+    @include('rapidez-ct::checkout.partials.address-card')
+</x-rapidez-ct::popup>

--- a/resources/views/components/popup.blade.php
+++ b/resources/views/components/popup.blade.php
@@ -3,7 +3,7 @@
 <input type="checkbox" id="popup" class="peer hidden"/>
 <div class="fixed inset-0 opacity-0 transition z-50 flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto">
     <x-rapidez-ct::sections class="relative z-10">
-        <x-rapidez-ct::card.inactive>
+        <x-rapidez-ct::card.inactive class="max-h-dvh overflow-y-auto scrollbar-hide relative xl:max-h-[calc(100dvh-44px)]">
             <label for="popup" class="absolute cursor-pointer z-10 top-7 right-7 w-5 h-5">
                 <x-heroicon-o-x-mark />
             </label>

--- a/resources/views/components/popup.blade.php
+++ b/resources/views/components/popup.blade.php
@@ -1,7 +1,7 @@
 @props(['title' => ''])
 
 <input type="checkbox" id="popup" class="peer hidden"/>
-<div class="fixed inset-0 opacity-0 transition max-h-full z-50 flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto">
+<div class="fixed inset-0 opacity-0 transition max-h-full z-50 flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto lg:py-5">
     <x-rapidez-ct::sections class="relative z-10 max-h-full overflow-y-auto scrollbar-hide">
         <x-rapidez-ct::card.inactive>
             <label for="popup" class="absolute cursor-pointer z-10 top-7 right-7 w-5 h-5">

--- a/resources/views/components/popup.blade.php
+++ b/resources/views/components/popup.blade.php
@@ -1,7 +1,7 @@
 @props(['title' => ''])
 
 <input type="checkbox" id="popup" class="peer hidden"/>
-<div class="fixed inset-0 opacity-0 transition max-h-full z-50 flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto lg:py-5">
+<div class="fixed inset-0 opacity-0 transition z-50 flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto lg:py-5">
     <x-rapidez-ct::sections class="relative z-10 max-h-full overflow-y-auto scrollbar-hide">
         <x-rapidez-ct::card.inactive>
             <label for="popup" class="absolute cursor-pointer z-10 top-7 right-7 w-5 h-5">

--- a/resources/views/components/popup.blade.php
+++ b/resources/views/components/popup.blade.php
@@ -1,10 +1,10 @@
-@props(['title' => ''])
+@props(['title' => '', 'id' => 'popup'])
 
-<input type="checkbox" id="popup" class="peer hidden"/>
+<input type="checkbox" id="{{ $id }}" class="peer hidden"/>
 <div class="fixed inset-0 opacity-0 transition z-50 flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto lg:py-5">
     <x-rapidez-ct::sections class="relative z-10 max-h-full overflow-y-auto scrollbar-hide">
         <x-rapidez-ct::card.inactive>
-            <label for="popup" class="absolute cursor-pointer z-10 top-7 right-7 w-5 h-5">
+            <label for="{{ $id }}" class="absolute cursor-pointer z-10 top-7 right-7 w-5 h-5">
                 <x-heroicon-o-x-mark />
             </label>
             @if($title)
@@ -15,5 +15,5 @@
             {{ $slot }}
         </x-rapidez-ct::card.inactive>
     </x-rapidez-ct::sections>
-    <label class="absolute inset-0 bg-ct-primary/60 cursor-pointer" for="popup"></label>
+    <label class="absolute inset-0 bg-ct-primary/60 cursor-pointer" for="{{ $id }}"></label>
 </div>

--- a/resources/views/components/popup.blade.php
+++ b/resources/views/components/popup.blade.php
@@ -1,9 +1,9 @@
 @props(['title' => ''])
 
 <input type="checkbox" id="popup" class="peer hidden"/>
-<div class="fixed inset-0 opacity-0 transition z-50 flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto">
-    <x-rapidez-ct::sections class="relative z-10">
-        <x-rapidez-ct::card.inactive class="max-h-dvh overflow-y-auto scrollbar-hide relative xl:max-h-[calc(100dvh-44px)]">
+<div class="fixed inset-0 opacity-0 transition max-h-full z-50 flex justify-center items-center pointer-events-none peer-checked:opacity-100 peer-checked:pointer-events-auto">
+    <x-rapidez-ct::sections class="relative z-10 max-h-full overflow-y-auto scrollbar-hide">
+        <x-rapidez-ct::card.inactive>
             <label for="popup" class="absolute cursor-pointer z-10 top-7 right-7 w-5 h-5">
                 <x-heroicon-o-x-mark />
             </label>


### PR DESCRIPTION
A few small fixes for the address popup see my screenshot below.

**When there are to much addresses in the popup it show like this:**
<img width="1728" alt="Scherm­afbeelding 2024-10-14 om 13 39 01" src="https://github.com/user-attachments/assets/18cad138-0c1a-4e79-952a-2c249fa83c69">

<img width="427" alt="Scherm­afbeelding 2024-10-14 om 13 59 33" src="https://github.com/user-attachments/assets/d41eb84a-f428-4cc3-af83-7e40dcb528d9">

_This is fixed for desktop & mobile:_
<img width="1728" alt="Scherm­afbeelding 2024-10-14 om 13 41 40" src="https://github.com/user-attachments/assets/1f140938-ab57-43d3-9bc1-b88fee68b8e9">

<img width="525" alt="Scherm­afbeelding 2024-10-14 om 13 52 05" src="https://github.com/user-attachments/assets/a82f369e-b158-44b4-a5a9-cea7b6612d40">

**From 640px the view will be like this:**
<img width="767" alt="Scherm­afbeelding 2024-10-14 om 13 53 09" src="https://github.com/user-attachments/assets/0ae6e57d-a6f1-4702-a74c-2fc6e722cfff">
_It will be shown from 1024px now (breakpoint lg)_

