### PR TITLE
Add "forgot password" link to checkout login section

### DIFF
--- a/resources/views/checkout/partials/sections/login/logged-out.blade.php
+++ b/resources/views/checkout/partials/sections/login/logged-out.blade.php
@@ -22,6 +22,7 @@
 
 <p v-if="!emailAvailable" class="self-end text-ct-inactive">
     @lang('You already have an account with this e-mail address. Please log in to continue.')
+    <a href="{{ route('account.forgotpassword') }}" class="underline hover:no-underline">@lang('Forgot your password?')</a>
 </p>
 <p v-else class="self-end text-ct-inactive">
     @lang('We will send your order confirmation to this e-mail address. We will also check if you already have an account so you can checkout more efficiently.')


### PR DESCRIPTION
The core [has this link in there already](https://github.com/rapidez/core/blob/2.x/resources/views/checkout/steps/login.blade.php#L31), but it was missing here. This is now fixed.

<img width="530" alt="image" src="https://github.com/user-attachments/assets/c623d590-7057-47d7-b438-fee7a26857ac">
