### PR TITLE
[2.x] Use v-model variable for is_subscribed setter

### DIFF
--- a/resources/views/components/newsletter/partials/checkbox.blade.php
+++ b/resources/views/components/newsletter/partials/checkbox.blade.php
@@ -5,7 +5,7 @@
     'id' => $id,
 ])" v-on:change="() => {
         if (typeof mutate === 'function' && (!{{ (int)$isPartOfAnotherForm }})) { mutate() }
-        if ($root.loggedIn) { $root.user.extension_attributes.is_subscribed=variables.is_subscribed }
+        if ($root.loggedIn) { $root.user.extension_attributes.is_subscribed={{ $attributes->get('v-model') }} }
     }">
     <x-slot:slot class="ml-2 flex flex-col gap-1">
         <span class="text-ct-primary text-sm font-medium">@lang('Yes, I want to subscribe to the newsletter')</span>


### PR DESCRIPTION
Previously this was only set to `variables.is_subscribed`, however this doesn't always exist or doesn't always represent the actual value we're looking for.

This went wrong with the newsletter in the checkout when logged in (but only in 2.x), as in that scenario it just uses `checkout.newsletter_subscribe` instead of a gql query.

