### PR TITLE
[3.x] Use v-model variable for is_subscribed setter

### DIFF
--- a/resources/views/components/newsletter/partials/checkbox.blade.php
+++ b/resources/views/components/newsletter/partials/checkbox.blade.php
@@ -5,7 +5,7 @@
     'id' => $id,
 ])" v-on:change="() => {
         if (typeof mutate === 'function' && (!{{ (int)$isPartOfAnotherForm }})) { mutate() }
-        if ($root.loggedIn) { $root.user.extension_attributes.is_subscribed=variables.is_subscribed }
+        if ($root.loggedIn) { $root.user.extension_attributes.is_subscribed={{ $attributes->get('v-model') }} }
     }">
     <x-slot:slot class="ml-2 flex flex-col gap-1">
         <span class="text-ct-primary text-sm font-medium">@lang('Yes, I want to subscribe to the newsletter')</span>


### PR DESCRIPTION
See #136

It's not necessarily a direct issue in 3.x because the checkout works differently here, but the issue with the component itself is still the same.