### PR TITLE
[3.x] Move card component outside of includes for more extendability

### DIFF
--- a/resources/views/account/edit.blade.php
+++ b/resources/views/account/edit.blade.php
@@ -8,10 +8,18 @@
     <graphql query="@include('rapidez::account.partials.queries.overview')" :callback="sortOrdersCallback">
         <div v-if="data" slot-scope="{ data, runQuery }">
             <x-rapidez-ct::sections>
-                @include('rapidez-ct::account.partials.sections.edit.addresses')
-                @include('rapidez-ct::account.partials.sections.edit.newsletter')
-                @include('rapidez-ct::account.partials.sections.edit.email')
-                @include('rapidez-ct::account.partials.sections.edit.password')
+                <x-rapidez-ct::card.inactive>
+                    @include('rapidez-ct::account.partials.sections.edit.addresses')
+                </x-rapidez-ct::card.inactive>
+                <x-rapidez-ct::card.inactive>
+                    @include('rapidez-ct::account.partials.sections.edit.newsletter')
+                </x-rapidez-ct::card.inactive>
+                <x-rapidez-ct::card.inactive>
+                    @include('rapidez-ct::account.partials.sections.edit.email')
+                </x-rapidez-ct::card.inactive>
+                <x-rapidez-ct::card.inactive>
+                    @include('rapidez-ct::account.partials.sections.edit.password')
+                </x-rapidez-ct::card.inactive>
             </x-rapidez-ct::sections>
             <x-rapidez-ct::toolbar>
                 <x-rapidez-ct::button.outline :href="route('account.overview')">

--- a/resources/views/account/forgotpassword.blade.php
+++ b/resources/views/account/forgotpassword.blade.php
@@ -11,8 +11,12 @@
                 @lang('Login')
             </x-rapidez-ct::title>
             <x-slot:columns>
-                @include('rapidez-ct::account.partials.forgotpassword')
-                @include('rapidez-ct::account.partials.register')
+                <x-rapidez-ct::card.inactive>
+                    @include('rapidez-ct::account.partials.forgotpassword')
+                </x-rapidez-ct::card.inactive>
+                <x-rapidez-ct::card class="md:w-auto">
+                    @include('rapidez-ct::account.partials.register')
+                </x-rapidez-ct::card>
             </x-slot:columns>
         </x-rapidez-ct::layout.two-column>
     </div>

--- a/resources/views/account/login.blade.php
+++ b/resources/views/account/login.blade.php
@@ -11,8 +11,12 @@
                 @lang('Login')
             </x-rapidez-ct::title>
             <x-slot:columns>
-                @include('rapidez-ct::account.partials.login')
-                @include('rapidez-ct::account.partials.register')
+                <x-rapidez-ct::card.inactive>
+                    @include('rapidez-ct::account.partials.login')
+                </x-rapidez-ct::card.inactive>
+                <x-rapidez-ct::card class="md:w-auto">
+                    @include('rapidez-ct::account.partials.register')
+                </x-rapidez-ct::card>
             </x-slot:columns>
         </x-rapidez-ct::layout.two-column>
     </div>

--- a/resources/views/account/order.blade.php
+++ b/resources/views/account/order.blade.php
@@ -25,7 +25,9 @@
         <div slot-scope="{ order: data }" v-if="order">
             <x-rapidez-ct::sections>
                 @include('rapidez-ct::account.partials.order.products')
-                @include('rapidez-ct::account.partials.order.order-info')
+                <x-rapidez-ct::card.inactive>
+                    @include('rapidez-ct::account.partials.order.order-info')
+                </x-rapidez-ct::card.inactive>
             </x-rapidez-ct::sections>
             <x-rapidez-ct::toolbar>
                 <x-rapidez-ct::button.outline href="/account/orders">

--- a/resources/views/account/partials/forgotpassword.blade.php
+++ b/resources/views/account/partials/forgotpassword.blade.php
@@ -4,35 +4,33 @@
     :clear="true"
     :notify="{ message: '@lang('An email is send with a password reset link if an account exists with the provided email address.')' }"
 >
-    <x-rapidez-ct::card.inactive slot-scope="{ mutate, variables }">
-        <form v-on:submit.prevent="mutate">
-            <x-rapidez-ct::title.lg class="mb-4">
-                @lang('Forgot Your Password?')
-            </x-rapidez-ct::title.lg>
-            <p class="mb-5 text-sm">
-                @lang('Enter your email address below, you will receive an email within minutes to reset the password.')
-            </p>
-            <x-rapidez-ct::input
-                name="email"
-                type="email"
-                v-model="variables.email"
-                label="Email"
-                required
-            />
-            <div class="mt-5 flex items-center justify-between">
-                <a href="{{ route('account.login') }}" class="text-sm text-ct-inactive underline">
-                    @lang('Back to login')
-                </a>
-                <x-rapidez-ct::button.accent
-                    class="flex items-center gap-1"
-                    type="submit"
-                    dusk="continue"
-                    loader
-                >
-                    @lang('Send')
-                    <x-heroicon-o-arrow-right class="h-4" />
-                </x-rapidez-ct::button.accent>
-            </div>
-        </form>
-    </x-rapidez-ct::card.inactive>
+    <form v-on:submit.prevent="mutate">
+        <x-rapidez-ct::title.lg class="mb-4">
+            @lang('Forgot Your Password?')
+        </x-rapidez-ct::title.lg>
+        <p class="mb-5 text-sm">
+            @lang('Enter your email address below, you will receive an email within minutes to reset the password.')
+        </p>
+        <x-rapidez-ct::input
+            name="email"
+            type="email"
+            v-model="variables.email"
+            label="Email"
+            required
+        />
+        <div class="mt-5 flex items-center justify-between">
+            <a href="{{ route('account.login') }}" class="text-sm text-ct-inactive underline">
+                @lang('Back to login')
+            </a>
+            <x-rapidez-ct::button.accent
+                class="flex items-center gap-1"
+                type="submit"
+                dusk="continue"
+                loader
+            >
+                @lang('Send')
+                <x-heroicon-o-arrow-right class="h-4" />
+            </x-rapidez-ct::button.accent>
+        </div>
+    </form>
 </graphql-mutation>

--- a/resources/views/account/partials/layout.blade.php
+++ b/resources/views/account/partials/layout.blade.php
@@ -38,8 +38,12 @@
                     @lang('Login')
                 </x-rapidez-ct::title>
                 <x-slot:columns>
-                    @include('rapidez-ct::account.partials.login', ['redirect' => false])
-                    @include('rapidez-ct::account.partials.register')
+                    <x-rapidez-ct::card.inactive>
+                        @include('rapidez-ct::account.partials.login', ['redirect' => false])
+                    </x-rapidez-ct::card.inactive>
+                    <x-rapidez-ct::card class="md:w-auto">
+                        @include('rapidez-ct::account.partials.register')
+                    </x-rapidez-ct::card>
                 </x-slot:columns>
             </x-rapidez-ct::layout.two-column>
         </template>

--- a/resources/views/account/partials/login.blade.php
+++ b/resources/views/account/partials/login.blade.php
@@ -1,33 +1,31 @@
 <login :checkout-login="false" v-slot="login" redirect="{{ $redirect ?? route('account.overview') }}">
-    <x-rapidez-ct::card.inactive>
-        <form class="space-y-5" v-on:submit.prevent="login.go()">
-            <x-rapidez-ct::input
-                name="email"
-                type="email"
-                label="Email"
-                v-model="login.email"
-                required
-            />
-            <x-rapidez-ct::input.password
-                name="password"
-                label="Password"
-                v-model="login.password"
-                required
-            />
-            <div class="flex items-center justify-between">
-                <a href="{{ route('account.forgotpassword') }}" class="text-sm text-ct-inactive underline">
-                    @lang('Forgot your password?')
-                </a>
-                <x-rapidez-ct::button.accent
-                    class="flex items-center gap-1"
-                    type="submit"
-                    dusk="continue"
-                    loader
-                >
-                    @lang('Login')
-                    <x-heroicon-o-arrow-right class="h-4" />
-                </x-rapidez-ct::button.accent>
-            </div>
-        </form>
-    </x-rapidez-ct::card.inactive>
+    <form class="space-y-5" v-on:submit.prevent="login.go()">
+        <x-rapidez-ct::input
+            name="email"
+            type="email"
+            label="Email"
+            v-model="login.email"
+            required
+        />
+        <x-rapidez-ct::input.password
+            name="password"
+            label="Password"
+            v-model="login.password"
+            required
+        />
+        <div class="flex items-center justify-between">
+            <a href="{{ route('account.forgotpassword') }}" class="text-sm text-ct-inactive underline">
+                @lang('Forgot your password?')
+            </a>
+            <x-rapidez-ct::button.accent
+                class="flex items-center gap-1"
+                type="submit"
+                dusk="continue"
+                loader
+            >
+                @lang('Login')
+                <x-heroicon-o-arrow-right class="h-4" />
+            </x-rapidez-ct::button.accent>
+        </div>
+    </form>
 </login>

--- a/resources/views/account/partials/order/order-info.blade.php
+++ b/resources/views/account/partials/order/order-info.blade.php
@@ -1,60 +1,58 @@
-<x-rapidez-ct::card.inactive>
-    <div class="flex flex-wrap -space-x-px max-sm:-space-y-px">
-        <div class="flex flex-1 flex-col -space-y-px">
-            <template v-if="order.hide_billing || hideBilling || order.shipping_address?.customer_address_id == order.billing_address?.customer_address_id">
-                <x-rapidez-ct::card.address
-                    v-bind:address="order.shipping_address"
-                    shipping
-                    billing
-                    check
-                />
-            </template>
-            <template v-else>
-                <x-rapidez-ct::card.address
-                    v-bind:address="order.shipping_address"
-                    shipping
-                    check
-                />
-                <x-rapidez-ct::card.address
-                    v-bind:address="order.billing_address"
-                    billing
-                    check
-                />
-            </template>
-        </div>
-        <div class="flex flex-1 flex-col -space-y-px">
-            <x-rapidez-ct::card.white class="flex-1" check>
-                <x-rapidez-ct::title.lg class="mb-4 pr-8">
-                    @lang('Payment method')
-                </x-rapidez-ct::title.lg>
-                <div class="flex flex-1 flex-wrap justify-between">
-                    <ul class="flex flex-col gap-1">
-                        <li v-for="data in order.payment_methods">
-                            @{{ data.name }}
-                        </li>
-                    </ul>
-                    @if (!empty($slot))
-                        <div class="mt-auto flex flex-col self-end">
-                            {{ $slot }}
-                        </div>
-                    @endif
-                </div>
-            </x-rapidez-ct::card.white>
-            <x-rapidez-ct::card.white class="flex-1" check>
-                <x-rapidez-ct::title.lg class="mb-4 pr-8">
-                    @lang('Delivery method')
-                </x-rapidez-ct::title.lg>
-                <div class="flex flex-1 flex-wrap justify-between">
-                    <ul class="flex flex-col gap-1">
-                        <li v-text="order.shipping_method"></li>
-                    </ul>
-                    @if (!empty($slot))
-                        <div class="mt-auto flex flex-col self-end">
-                            {{ $slot }}
-                        </div>
-                    @endif
-                </div>
-            </x-rapidez-ct::card.white>
-        </div>
+<div class="flex flex-wrap -space-x-px max-sm:-space-y-px">
+    <div class="flex flex-1 flex-col -space-y-px">
+        <template v-if="order.hide_billing || hideBilling || order.shipping_address?.customer_address_id == order.billing_address?.customer_address_id">
+            <x-rapidez-ct::card.address
+                v-bind:address="order.shipping_address"
+                shipping
+                billing
+                check
+            />
+        </template>
+        <template v-else>
+            <x-rapidez-ct::card.address
+                v-bind:address="order.shipping_address"
+                shipping
+                check
+            />
+            <x-rapidez-ct::card.address
+                v-bind:address="order.billing_address"
+                billing
+                check
+            />
+        </template>
     </div>
-</x-rapidez-ct::card.inactive>
+    <div class="flex flex-1 flex-col -space-y-px">
+        <x-rapidez-ct::card.white class="flex-1" check>
+            <x-rapidez-ct::title.lg class="mb-4 pr-8">
+                @lang('Payment method')
+            </x-rapidez-ct::title.lg>
+            <div class="flex flex-1 flex-wrap justify-between">
+                <ul class="flex flex-col gap-1">
+                    <li v-for="data in order.payment_methods">
+                        @{{ data.name }}
+                    </li>
+                </ul>
+                @if (!empty($slot))
+                    <div class="mt-auto flex flex-col self-end">
+                        {{ $slot }}
+                    </div>
+                @endif
+            </div>
+        </x-rapidez-ct::card.white>
+        <x-rapidez-ct::card.white class="flex-1" check>
+            <x-rapidez-ct::title.lg class="mb-4 pr-8">
+                @lang('Delivery method')
+            </x-rapidez-ct::title.lg>
+            <div class="flex flex-1 flex-wrap justify-between">
+                <ul class="flex flex-col gap-1">
+                    <li v-text="order.shipping_method"></li>
+                </ul>
+                @if (!empty($slot))
+                    <div class="mt-auto flex flex-col self-end">
+                        {{ $slot }}
+                    </div>
+                @endif
+            </div>
+        </x-rapidez-ct::card.white>
+    </div>
+</div>

--- a/resources/views/account/partials/register-account.blade.php
+++ b/resources/views/account/partials/register-account.blade.php
@@ -97,7 +97,9 @@
                 </x-rapidez-ct::card.inactive>
             @endif
 
-            <x-rapidez-ct::newsletter v-model="variables.is_subscribed"/>
+            <x-rapidez-ct::card.inactive>
+                <x-rapidez-ct::newsletter v-model="variables.is_subscribed"/>
+            </x-rapidez-ct::card.inactive>
         </x-rapidez-ct::sections>
     </graphql-mutation>
 </graphql-mutation>

--- a/resources/views/account/partials/register.blade.php
+++ b/resources/views/account/partials/register.blade.php
@@ -1,12 +1,10 @@
-<x-rapidez-ct::card class="md:w-auto">
-    <x-rapidez-ct::title.lg class="mb-4">
-        @lang('Register within 1 minute')
-    </x-rapidez-ct::title.lg>
-    <p class="mb-5 text-sm">
-        @lang('Don\'t have an account yet? Create an account and enjoy faster ordering, repeat orders, status of your order, easy returns and more!')
-    </p>
-    <x-rapidez-ct::button.outline :href="route('account.register')" class="flex w-fit items-center gap-1">
-        @lang('Register')
-        <x-heroicon-o-arrow-right class="h-4" />
-    </x-rapidez-ct::button.outline>
-</x-rapidez-ct::card>
+<x-rapidez-ct::title.lg class="mb-4">
+    @lang('Register within 1 minute')
+</x-rapidez-ct::title.lg>
+<p class="mb-5 text-sm">
+    @lang('Don\'t have an account yet? Create an account and enjoy faster ordering, repeat orders, status of your order, easy returns and more!')
+</p>
+<x-rapidez-ct::button.outline :href="route('account.register')" class="flex w-fit items-center gap-1">
+    @lang('Register')
+    <x-heroicon-o-arrow-right class="h-4" />
+</x-rapidez-ct::button.outline>

--- a/resources/views/account/partials/resetpassword.blade.php
+++ b/resources/views/account/partials/resetpassword.blade.php
@@ -5,31 +5,29 @@
     :clear="true"
     :notify="{ message: '@lang('Your password has been changed, please login.')' }"
 >
-    <x-rapidez-ct::card.inactive slot-scope="{ mutate, variables }">
-        <form class="space-y-5" v-on:submit.prevent="mutate">
-            <x-rapidez-ct::input
-                name="token"
-                v-model="variables.token"
-                label="Security token"
-                required
-            />
-            <x-rapidez-ct::input
-                name="email"
-                type="email"
-                label="Email"
-                v-model="variables.email"
-                required
-            />
-            <x-rapidez-ct::input
-                name="password"
-                type="password"
-                v-model="variables.password"
-                label="New password"
-                required
-            />
-            <x-rapidez-ct::button.accent type="submit" class="w-full">
-                @lang('Change password')
-            </x-rapidez-ct::button.accent>
-        </form>
-    </x-rapidez-ct::card.inactive>
+    <form class="space-y-5" v-on:submit.prevent="mutate" slot-scope="{ mutate, variables }">
+        <x-rapidez-ct::input
+            name="token"
+            v-model="variables.token"
+            label="Security token"
+            required
+        />
+        <x-rapidez-ct::input
+            name="email"
+            type="email"
+            label="Email"
+            v-model="variables.email"
+            required
+        />
+        <x-rapidez-ct::input
+            name="password"
+            type="password"
+            v-model="variables.password"
+            label="New password"
+            required
+        />
+        <x-rapidez-ct::button.accent type="submit" class="w-full">
+            @lang('Change password')
+        </x-rapidez-ct::button.accent>
+    </form>
 </graphql-mutation>

--- a/resources/views/account/partials/sections/edit/addresses.blade.php
+++ b/resources/views/account/partials/sections/edit/addresses.blade.php
@@ -1,10 +1,8 @@
-<x-rapidez-ct::card.inactive>
-    <div
-        v-if="data?.customer?.addresses"
-        v-bind:set-billing="data.customer.billing_address = data.customer.addresses.find(e => e.default_billing)"
-        v-bind:set-shipping="data.customer.shipping_address = data.customer.addresses.find(e => e.default_shipping)"
-    >
-        @include('rapidez-ct::account.partials.address-cards')
-        @include('rapidez-ct::account.partials.address-cards-popup')
-    </div>
-</x-rapidez-ct::card.inactive>
+<div
+    v-if="data?.customer?.addresses"
+    v-bind:set-billing="data.customer.billing_address = data.customer.addresses.find(e => e.default_billing)"
+    v-bind:set-shipping="data.customer.shipping_address = data.customer.addresses.find(e => e.default_shipping)"
+>
+    @include('rapidez-ct::account.partials.address-cards')
+    @include('rapidez-ct::account.partials.address-cards-popup')
+</div>

--- a/resources/views/account/partials/sections/edit/email.blade.php
+++ b/resources/views/account/partials/sections/edit/email.blade.php
@@ -1,37 +1,35 @@
-<x-rapidez-ct::card.inactive>
-    <graphql-mutation
-        query="mutation email ($email: String!, $password: String!) { updateCustomerEmail ( email: $email, password: $password ) { customer { email } } }"
-        :clear="true"
-        :callback="refreshUserInfoCallback"
-        :variables="{ email: user.email }"
-    >
-        <form class="grid gap-5 grid-cols-2" slot-scope="{ variables, mutate, mutated }" v-on:submit.prevent="mutate">
-            <x-rapidez-ct::title.lg class="col-span-2">
+<graphql-mutation
+    query="mutation email ($email: String!, $password: String!) { updateCustomerEmail ( email: $email, password: $password ) { customer { email } } }"
+    :clear="true"
+    :callback="refreshUserInfoCallback"
+    :variables="{ email: user.email }"
+>
+    <form class="grid gap-5 grid-cols-2" slot-scope="{ variables, mutate, mutated }" v-on:submit.prevent="mutate">
+        <x-rapidez-ct::title.lg class="col-span-2">
+            @lang('Change e-mail address')
+        </x-rapidez-ct::title.lg>
+        <x-rapidez-ct::input
+            name="email"
+            label="Email"
+            v-model="variables.email"
+            required
+        />
+        <x-rapidez-ct::input
+            type="password"
+            label="Password"
+            name="password"
+            v-model="variables.password"
+            required
+        />
+
+        <div class="flex items-center col-span-full">
+            <x-rapidez-ct::button.accent type="submit">
                 @lang('Change e-mail address')
-            </x-rapidez-ct::title.lg>
-            <x-rapidez-ct::input
-                name="email"
-                label="Email"
-                v-model="variables.email"
-                required
-            />
-            <x-rapidez-ct::input
-                type="password"
-                label="Password"
-                name="password"
-                v-model="variables.password"
-                required
-            />
+            </x-rapidez-ct::button.accent>
 
-            <div class="flex items-center col-span-full">
-                <x-rapidez-ct::button.accent type="submit">
-                    @lang('Change e-mail address')
-                </x-rapidez-ct::button.accent>
-
-                <div v-if="mutated" class="ml-3 text-green-500">
-                    @lang('Changed successfully!')
-                </div>
+            <div v-if="mutated" class="ml-3 text-green-500">
+                @lang('Changed successfully!')
             </div>
-        </form>
-    <graphql-mutation>
-</x-rapidez-ct::card.inactive>
+        </div>
+    </form>
+<graphql-mutation>

--- a/resources/views/account/partials/sections/edit/password.blade.php
+++ b/resources/views/account/partials/sections/edit/password.blade.php
@@ -1,36 +1,34 @@
-<x-rapidez-ct::card.inactive>
-    <graphql-mutation
-        query="mutation password ($currentPassword: String!, $newPassword: String!) { changeCustomerPassword ( currentPassword: $currentPassword, newPassword: $newPassword ) { email } }"
-        :clear="true"
-    >
-        <form class="grid gap-5 grid-cols-2" slot-scope="{ variables, mutate, mutated }" v-on:submit.prevent="mutate">
-            <x-rapidez-ct::title.lg class="col-span-2">
+<graphql-mutation
+    query="mutation password ($currentPassword: String!, $newPassword: String!) { changeCustomerPassword ( currentPassword: $currentPassword, newPassword: $newPassword ) { email } }"
+    :clear="true"
+>
+    <form class="grid gap-5 grid-cols-2" slot-scope="{ variables, mutate, mutated }" v-on:submit.prevent="mutate">
+        <x-rapidez-ct::title.lg class="col-span-2">
+            @lang('Change password')
+        </x-rapidez-ct::title.lg>
+        <x-rapidez-ct::input
+            type="password"
+            label="Current password"
+            name="currentPassword"
+            v-model="variables.currentPassword"
+            required
+        />
+        <x-rapidez-ct::input
+            type="password"
+            label="New password"
+            name="newPassword"
+            v-model="variables.newPassword"
+            required
+        />
+
+        <div class="flex items-center col-span-full">
+            <x-rapidez-ct::button.accent type="submit">
                 @lang('Change password')
-            </x-rapidez-ct::title.lg>
-            <x-rapidez-ct::input
-                type="password"
-                label="Current password"
-                name="currentPassword"
-                v-model="variables.currentPassword"
-                required
-            />
-            <x-rapidez-ct::input
-                type="password"
-                label="New password"
-                name="newPassword"
-                v-model="variables.newPassword"
-                required
-            />
+            </x-rapidez-ct::button.accent>
 
-            <div class="flex items-center col-span-full">
-                <x-rapidez-ct::button.accent type="submit">
-                    @lang('Change password')
-                </x-rapidez-ct::button.accent>
-
-                <div v-if="mutated" class="ml-3 text-green-500">
-                    @lang('Changed successfully!')
-                </div>
+            <div v-if="mutated" class="ml-3 text-green-500">
+                @lang('Changed successfully!')
             </div>
-        </form>
-    <graphql-mutation>
-</x-rapidez-ct::card.inactive>
+        </div>
+    </form>
+<graphql-mutation>

--- a/resources/views/account/resetpassword.blade.php
+++ b/resources/views/account/resetpassword.blade.php
@@ -11,8 +11,12 @@
                 @lang('Reset password')
             </x-rapidez-ct::title>
             <x-slot:columns>
-                @include('rapidez-ct::account.partials.resetpassword')
-                @include('rapidez-ct::account.partials.register')
+                <x-rapidez-ct::card.inactive>
+                    @include('rapidez-ct::account.partials.resetpassword')
+                </x-rapidez-ct::card.inactive>
+                <x-rapidez-ct::card class="md:w-auto">
+                    @include('rapidez-ct::account.partials.register')
+                </x-rapidez-ct::card>
             </x-slot:columns>
         </x-rapidez-ct::layout.two-column>
     </div>

--- a/resources/views/checkout/partials/sections/address.blade.php
+++ b/resources/views/checkout/partials/sections/address.blade.php
@@ -1,10 +1,9 @@
 <checkout-address v-slot="{ useCards, editing, toggleEdit }">
-    <x-rapidez-ct::card.inactive v-if="useCards && !editing">
+    <template v-if="useCards && !editing">
         @include('rapidez-ct::checkout.partials.address-cards')
         @include('rapidez-ct::checkout.partials.buttons.address')
-    </x-rapidez-ct::card.inactive>
-
-    <x-rapidez-ct::card.inactive v-else>
+    </template>
+    <template v-else>
         <graphql-mutation
             :query="config.queries.setNewShippingAddressesOnCart"
             :variables="{
@@ -47,5 +46,5 @@
                 @include('rapidez-ct::checkout.partials.shipping-billing-fields', ['type' => 'billing'])
             </fieldset>
         </graphql-mutation>
-    </x-rapidez-ct::card.inactive>
+    </template>
 </checkout-address>

--- a/resources/views/checkout/partials/sections/login.blade.php
+++ b/resources/views/checkout/partials/sections/login.blade.php
@@ -1,12 +1,10 @@
 <login v-slot="{ email, password, go, loginInputChange, emailAvailable, logout }">
-    <x-rapidez-ct::card.inactive>
+    <div class="grid gap-4 sm:gap-5 md:grid-cols-2 md:items-end">
         <template v-if="!loggedIn">
             @include('rapidez-ct::checkout.partials.sections.login.logged-out')
         </template>
         <template v-else>
-            <div class="grid gap-4 sm:gap-5 md:grid-cols-2 md:items-end">
-                @include('rapidez-ct::checkout.partials.sections.login.logged-in')
-            </div>
+            @include('rapidez-ct::checkout.partials.sections.login.logged-in')
         </template>
-    </x-rapidez-ct::card.inactive>
+    </div>
 </login>

--- a/resources/views/checkout/partials/sections/shipping.blade.php
+++ b/resources/views/checkout/partials/sections/shipping.blade.php
@@ -1,7 +1,5 @@
-<x-rapidez-ct::card.inactive>
-    <x-rapidez-ct::title.lg>
-        @lang('Shipping method')
-    </x-rapidez-ct::title.lg>
+<x-rapidez-ct::title.lg>
+    @lang('Shipping method')
+</x-rapidez-ct::title.lg>
 
-    @include('rapidez-ct::checkout.partials.shipping.methods')
-</x-rapidez-ct::card.inactive>
+@include('rapidez-ct::checkout.partials.shipping.methods')

--- a/resources/views/checkout/partials/sections/success/create-account.blade.php
+++ b/resources/views/checkout/partials/sections/success/create-account.blade.php
@@ -1,4 +1,4 @@
-<x-rapidez-ct::card.inactive v-if="!$root.loggedIn">
+<template v-if="!$root.loggedIn">
     @include('rapidez-ct::checkout.partials.sections.success.create-account-title')
     <graphql-mutation
         v-cloak
@@ -35,7 +35,7 @@
             @include('rapidez-ct::checkout.partials.sections.success.create-account-button')
         </form>
     </graphql-mutation>
-</x-rapidez-ct::card.inactive>
-<x-rapidez-ct::card.inactive v-else>
+</template>
+<template v-else>
     @include('rapidez-ct::checkout.partials.sections.success.logged-in')
-</x-rapidez-ct::card.inactive>
+</template>

--- a/resources/views/checkout/partials/sections/success/order-completed-note.blade.php
+++ b/resources/views/checkout/partials/sections/success/order-completed-note.blade.php
@@ -1,9 +1,7 @@
-<x-rapidez-ct::card.inactive class="!bg-ct-accent/20">
-    <x-rapidez-ct::title.lg>
-        @lang('We will get to work for you right away')
-    </x-rapidez-ct::title.lg>
-    <p class="mt-4 text-sm">
-        @lang('We will send a confirmation of your order :orderid to :email', ['orderid' => '@{{ order.number }}', 'email' => '@{{ order.email }}'])
-    </p>
-    <p class="mt-4 text-sm">@lang('Your order is currently'): <span class="font-bold" v-blur>@{{ order.status }}</span> <a class="inline-block" href="#" v-on:click.prevent="(e) => {e.target.classList.add('animate-spin'); refreshOrder().finally(() => e.target.classList.remove('animate-spin'))}">&#8635;</a></p>
-</x-rapidez-ct::card.inactive>
+<x-rapidez-ct::title.lg>
+    @lang('We will get to work for you right away')
+</x-rapidez-ct::title.lg>
+<p class="mt-4 text-sm">
+    @lang('We will send a confirmation of your order :orderid to :email', ['orderid' => '@{{ order.number }}', 'email' => '@{{ order.email }}'])
+</p>
+<p class="mt-4 text-sm">@lang('Your order is currently'): <span class="font-bold" v-blur>@{{ order.status }}</span> <a class="inline-block" href="#" v-on:click.prevent="(e) => {e.target.classList.add('animate-spin'); refreshOrder().finally(() => e.target.classList.remove('animate-spin'))}">&#8635;</a></p>

--- a/resources/views/checkout/partials/sidebar/sidebar.blade.php
+++ b/resources/views/checkout/partials/sidebar/sidebar.blade.php
@@ -1,2 +1,5 @@
-@include('rapidez-ct::checkout.partials.sidebar.summary')
+<x-rapidez-ct::card>
+    @include('rapidez-ct::checkout.partials.sidebar.summary')
+</x-rapidez-ct::card>
+
 @include('rapidez-ct::checkout.partials.sidebar.user-info')

--- a/resources/views/checkout/partials/sidebar/summary.blade.php
+++ b/resources/views/checkout/partials/sidebar/summary.blade.php
@@ -1,16 +1,14 @@
-<x-rapidez-ct::card class="relative">
-    <a href="{{ url('/') }}" class="absolute inset-x-0 bottom-full -translate-y-6 max-lg:hidden *:h-auto *:max-h-20 *:w-full *:object-contain">
-        <x-rapidez-ct::logo />
-    </a>
-    <x-rapidez-ct::title.lg class="mb-4">
-        @lang('Order overview')
-    </x-rapidez-ct::title.lg>
-    <x-rapidez-ct::separated-listing class="border-b pb-4 mb-4" v-cloak>
-        <li v-for="item in cart.items">
-            @{{ item.quantity }}x @{{ item.product.name }}
-        </li>
-    </x-rapidez-ct::separated-listing>
-    <x-rapidez-ct::separated-listing tag="dl">
-            @include('rapidez-ct::checkout.partials.sidebar.totals')
-    </x-rapidez-ct::separated-listing>
-</x-rapidez-ct::card>
+<a href="{{ url('/') }}" class="absolute inset-x-0 bottom-full -translate-y-6 max-lg:hidden *:h-auto *:max-h-20 *:w-full *:object-contain">
+    <x-rapidez-ct::logo />
+</a>
+<x-rapidez-ct::title.lg class="mb-4">
+    @lang('Order overview')
+</x-rapidez-ct::title.lg>
+<x-rapidez-ct::separated-listing class="border-b pb-4 mb-4" v-cloak>
+    <li v-for="item in cart.items">
+        @{{ item.quantity }}x @{{ item.product.name }}
+    </li>
+</x-rapidez-ct::separated-listing>
+<x-rapidez-ct::separated-listing tag="dl">
+        @include('rapidez-ct::checkout.partials.sidebar.totals')
+</x-rapidez-ct::separated-listing>

--- a/resources/views/checkout/steps/credentials.blade.php
+++ b/resources/views/checkout/steps/credentials.blade.php
@@ -1,6 +1,16 @@
 <x-rapidez-ct::sections>
-    @includeWhen(!in_array('login', $checkoutSteps), 'rapidez-ct::checkout.partials.sections.login')
-    @include('rapidez-ct::checkout.partials.sections.address')
-    @include('rapidez-ct::checkout.partials.sections.newsletter')
-    @include('rapidez-ct::checkout.partials.sections.shipping')
+    @unless (in_array('login', $checkoutSteps))
+        <x-rapidez-ct::card.inactive>
+            @include('rapidez-ct::checkout.partials.sections.login')
+        </x-rapidez-ct::card.inactive>
+    @endunless
+    <x-rapidez-ct::card.inactive>
+        @include('rapidez-ct::checkout.partials.sections.address')
+    </x-rapidez-ct::card.inactive>
+    <x-rapidez-ct::card.inactive>
+        @include('rapidez-ct::checkout.partials.sections.newsletter')
+    </x-rapidez-ct::card.inactive>
+    <x-rapidez-ct::card.inactive>
+        @include('rapidez-ct::checkout.partials.sections.shipping')
+    </x-rapidez-ct::card.inactive>
 </x-rapidez-ct::sections>

--- a/resources/views/checkout/steps/success.blade.php
+++ b/resources/views/checkout/steps/success.blade.php
@@ -7,17 +7,26 @@
             </x-rapidez-ct::title>
         
             <x-rapidez-ct::sections>
+                <x-rapidez-ct::card.inactive class="!bg-ct-accent/20">
                 @include('rapidez-ct::checkout.partials.sections.success.order-completed-note')
+            </x-rapidez-ct::card.inactive>
             </x-rapidez-ct::sections>
 
             <x-rapidez-ct::sections>
-                @include('rapidez-ct::checkout.partials.sections.success.order-info')
+                <x-rapidez-ct::card.inactive>
+                    @include('rapidez-ct::checkout.partials.sections.success.order-info')
+                </x-rapidez-ct::card.inactive>
+
                 @include('rapidez-ct::checkout.partials.sections.success.products')
-                @include('rapidez-ct::checkout.partials.sections.success.newsletter')
-                @includeWhen(
-                    config('rapidez.checkout-theme.checkout.success.register'),
-                    'rapidez-ct::checkout.partials.sections.success.create-account'
-                )
+
+                <x-rapidez-ct::card.inactive>
+                    @include('rapidez-ct::checkout.partials.sections.success.newsletter')
+                </x-rapidez-ct::card.inactive>  
+                <x-rapidez-ct::card.inactive>
+                    @if (config('rapidez.checkout-theme.checkout.success.register'))
+                        @include('rapidez-ct::checkout.partials.sections.success.create-account')
+                    @endif
+                </x-rapidez-ct::card.inactive>
             </x-rapidez-ct::sections>
             <x-slot:sidebar>
                 @include('rapidez-ct::checkout.partials.sections.success.features')

--- a/resources/views/components/card/inactive.blade.php
+++ b/resources/views/components/card/inactive.blade.php
@@ -1,3 +1,3 @@
-<div {{ $attributes->class('bg-ct-inactive-100 px-6 pt-6 pb-6 sm:px-9 sm:pt-7 sm:pb-9 rounded') }}>
+<div {{ $attributes->class('relative bg-ct-inactive-100 px-6 pt-6 pb-6 sm:px-9 sm:pt-7 sm:pb-9 rounded') }}>
     {{ $slot }}
 </div>

--- a/resources/views/components/card/index.blade.php
+++ b/resources/views/components/card/index.blade.php
@@ -1,4 +1,4 @@
-<div {{ $attributes->class('flex bg-ct-inactive-100 p-3 rounded lg:w-[340px] xl:w-[370px]') }}>
+<div {{ $attributes->class('relative flex bg-ct-inactive-100 p-3 rounded lg:w-[340px] xl:w-[370px]') }}>
     <x-rapidez-ct::card.white>
         {{ $slot }}
     </x-rapidez-ct::card.white>

--- a/resources/views/components/newsletter/index.blade.php
+++ b/resources/views/components/newsletter/index.blade.php
@@ -1,33 +1,31 @@
 @props(['id' => uniqId('newsletter-'), 'hasData' => false])
 
-<x-rapidez-ct::card.inactive>
-    <x-rapidez-ct::title.lg class="mb-5">
-        @lang('Newsletter')
-    </x-rapidez-ct::title.lg>
+<x-rapidez-ct::title.lg class="mb-5">
+    @lang('Newsletter')
+</x-rapidez-ct::title.lg>
 
-    @if (!$attributes->has('v-model'))
-        @php
-            $subscribedData = $hasData
-                ? 'data?.customer?.is_subscribed ?? $root.user?.extension_attributes?.is_subscribed ?? false'
-                : '$root.user?.extension_attributes?.is_subscribed ?? false'
-        @endphp
-        <graphql-mutation
-            v-cloak
-            :query="user.is_logged_in ? 'mutation subscribeNewsletter ($is_subscribed: Boolean!) { updateCustomerV2(input: { is_subscribed: $is_subscribed }) { customer { is_subscribed } } }' : 'mutation visitor ($email: String!) { subscribeEmailToNewsletter(email: $email) { status } }'"
-            :alert="false"
-            :clear="false"
-            :variables="{ is_subscribed: {{ $subscribedData }}, email: {{ $email ?? 'user.email || cart.email' }} }"
-            v-slot="{ mutate, variables }"
-        >
-    @endif
+@if (!$attributes->has('v-model'))
+    @php
+        $subscribedData = $hasData
+            ? 'data?.customer?.is_subscribed ?? $root.user?.extension_attributes?.is_subscribed ?? false'
+            : '$root.user?.extension_attributes?.is_subscribed ?? false'
+    @endphp
+    <graphql-mutation
+        v-cloak
+        :query="user.is_logged_in ? 'mutation subscribeNewsletter ($is_subscribed: Boolean!) { updateCustomerV2(input: { is_subscribed: $is_subscribed }) { customer { is_subscribed } } }' : 'mutation visitor ($email: String!) { subscribeEmailToNewsletter(email: $email) { status } }'"
+        :alert="false"
+        :clear="false"
+        :variables="{ is_subscribed: {{ $subscribedData }}, email: {{ $email ?? 'user.email || cart.email' }} }"
+        v-slot="{ mutate, variables }"
+    >
+@endif
 
-    <x-rapidez-ct::newsletter.partials.checkbox
-        :v-model="$attributes->has('v-model') ? $attributes['v-model'] : 'variables.is_subscribed'"
-        :isPartOfAnotherForm="$attributes->has('v-model')"
-        :$id
-    />
+<x-rapidez-ct::newsletter.partials.checkbox
+    :v-model="$attributes->has('v-model') ? $attributes['v-model'] : 'variables.is_subscribed'"
+    :isPartOfAnotherForm="$attributes->has('v-model')"
+    :$id
+/>
 
-    @if (!$attributes->has('v-model'))
-        </graphql-mutation>
-    @endif
-</x-rapidez-ct::card.inactive>
+@if (!$attributes->has('v-model'))
+    </graphql-mutation>
+@endif

--- a/resources/views/components/newsletter/input.blade.php
+++ b/resources/views/components/newsletter/input.blade.php
@@ -1,18 +1,16 @@
 @props(['id' => uniqId('newsletter-'), 'email' => "''"])
 
-<x-rapidez-ct::card.inactive class="relative">
-    <x-rapidez-ct::title.lg class="mb-5">
-        @lang('Newsletter')
-    </x-rapidez-ct::title.lg>
-    <graphql-mutation
-        v-cloak
-        query="mutation visitor ($email: String!) { subscribeEmailToNewsletter(email: $email) { status } }"
-        :variables="{ email: {{ $email }} }"
-        :clear="true"
-        :notify="{ message: '@lang('Thank you for subscribing')', type: 'success' }"
-    >
-        <template slot-scope="{ mutate, variables, mutated, mutating, error }">
-            <x-rapidez-ct::newsletter.partials.input />
-        </template>
-    </graphql-mutation>
-</x-rapidez-ct::card.inactive>
+<x-rapidez-ct::title.lg class="mb-5">
+    @lang('Newsletter')
+</x-rapidez-ct::title.lg>
+<graphql-mutation
+    v-cloak
+    query="mutation visitor ($email: String!) { subscribeEmailToNewsletter(email: $email) { status } }"
+    :variables="{ email: {{ $email }} }"
+    :clear="true"
+    :notify="{ message: '@lang('Thank you for subscribing')', type: 'success' }"
+>
+    <template slot-scope="{ mutate, variables, mutated, mutating, error }">
+        <x-rapidez-ct::newsletter.partials.input />
+    </template>
+</graphql-mutation>


### PR DESCRIPTION
3.x version of #100

Description copied from there:

> This is a proposed optimization to make extendability a bit better without adding any complexity.
> 
> Basically https://github.com/rapidez/checkout-theme/pull/98 but then everywhere instead of just one include for consistency.

This is one of those breaking changes we waited to merge until 3.x was ready, so here it is.