### PR TITLE
[2.x] Clone address when selecting

### DIFF
--- a/resources/js/components/CheckoutAddress.vue
+++ b/resources/js/components/CheckoutAddress.vue
@@ -31,7 +31,7 @@
             },
 
             select(type, address) {
-                this.$root.checkout[`${type}_address`] = address
+                this.$root.checkout[`${type}_address`] = JSON.parse(JSON.stringify(address))
                 this.$root.checkout[`${type}_address`].customer_address_id = address.id
             },
         },


### PR DESCRIPTION
This is the same issue as https://github.com/rapidez/core/pull/656.

In this case if you end up selecting the same address for both shipping and billing within the address popup and then try to change them within the checkout, the addresses will be synced in the same way.