### PR TITLE
[3.x] Use x-rapidez::tag

### DIFF
--- a/resources/views/components/button/base.blade.php
+++ b/resources/views/components/button/base.blade.php
@@ -1,5 +1,5 @@
 @props(['loader' => false, 'tag'])
-<x-tag
+<x-rapidez::tag
     is="{{ $tag ?? ($attributes->has('href') || $attributes->has('v-bind:href') ? 'a' : 'button') }}"
     {{ $attributes->class([
         'relative inline-block self-start text-center text-sm transition cursor-pointer',
@@ -15,4 +15,4 @@
     <span class="contents" @attributes([':class' => $loader ? '{ "invisible": $root.loading }' : false])>
         {{ $slot }}
     </span>
-</x-tag>
+</x-rapidez::tag>

--- a/resources/views/components/button/link.blade.php
+++ b/resources/views/components/button/link.blade.php
@@ -1,7 +1,7 @@
 @props(['tag'])
-<x-tag
+<x-rapidez::tag
     is="{{ $tag ?? ($attributes->has('href') || $attributes->has('v-bind:href') ? 'a' : 'button') }}"
     {{ $attributes->merge(['class' => 'underline text-ct-inactive text-right disabled:no-underline disabled:cursor-not-allowed disabled:opacity-50']) }}
 >
     {{ $slot }}
-</x-tag>
+</x-rapidez::tag>

--- a/resources/views/components/dashboard/item/index.blade.php
+++ b/resources/views/components/dashboard/item/index.blade.php
@@ -1,5 +1,5 @@
 @props(['item' => [], 'key' => ''])
-<x-tag {{ $attributes->merge([
+<x-rapidez::tag {{ $attributes->merge([
     'class' => 'flex flex-wrap items-center gap-x-6 rounded border bg-white px-8 py-4 text-left',
     'href' => $item['href'] ?? '',
     'is' => isset($item['href']) ? 'a' : 'button',
@@ -27,4 +27,4 @@
         @endif
     </div>
     <x-heroicon-o-chevron-right class="ml-auto h-4" />
-</x-tag>
+</x-rapidez::tag>

--- a/resources/views/components/dashboard/sidebar-item/index.blade.php
+++ b/resources/views/components/dashboard/sidebar-item/index.blade.php
@@ -1,5 +1,5 @@
 @props(['item' => [], 'key' => ''])
-<x-tag {{ $attributes->merge([
+<x-rapidez::tag {{ $attributes->merge([
     'class' => 'flex-1 text-left',
     'is' => isset($item['href']) ? 'a' : 'button',
     'href' => $item['href'] ?? '',
@@ -13,4 +13,4 @@
         </graphql>
     @endif
     <x-heroicon-o-chevron-right class="h-4" />
-</x-tag>
+</x-rapidez::tag>

--- a/resources/views/components/separated-listing/index.blade.php
+++ b/resources/views/components/separated-listing/index.blade.php
@@ -1,4 +1,4 @@
 @props(['tag' => 'ul'])
-<x-tag is="{{ $tag }}" {{ $attributes->class('flex flex-col text-sm mt-1 divide-y [&>*]:py-4 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0 [&>*]:flex [&>*]:flex-wrap [&>*]:justify-between') }}>
+<x-rapidez::tag is="{{ $tag }}" {{ $attributes->class('flex flex-col text-sm mt-1 divide-y [&>*]:py-4 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0 [&>*]:flex [&>*]:flex-wrap [&>*]:justify-between') }}>
     {{ $slot }}
-</x-tag>
+</x-rapidez::tag>


### PR DESCRIPTION
As this component is now integrated into `rapidez/blade-components`, an update that also comes with rapidez v3, its signature has been changed to `x-rapidez::tag`.