### PR TITLE
[3.x] Fix getCart query & styling for payment step & button label

### DIFF
--- a/resources/views/cart/overview.blade.php
+++ b/resources/views/cart/overview.blade.php
@@ -6,7 +6,7 @@
 
 @section('content')
     <graphql v-if="mask"
-        :query="'query getCart($cart_id: String!) { cart (cart_id: $cart_id) { ' + config.queries.cart + ' } }'"
+        :query="'query getCart($cart_id: String!) { cart (cart_id: $cart_id) { ...cart } } ' + config.fragments.cart"
         :variables="{ cart_id: mask }" 
         :callback="updateCart" 
         :error-callback="checkResponseForExpiredCart"

--- a/resources/views/checkout/partials/sections/payment.blade.php
+++ b/resources/views/checkout/partials/sections/payment.blade.php
@@ -11,7 +11,7 @@
     mutate-event="setPaymentMethodOnCart"
     v-slot="{ mutate, variables }"
 >
-    <div partial-submit="mutate">
+    <div partial-submit="mutate" class="flex flex-col gap-4">
         <div v-for="(method, index) in cart.available_payment_methods">
             @include('rapidez-ct::checkout.partials.sections.payment.payment-methods')
         </div>

--- a/resources/views/components/button/base.blade.php
+++ b/resources/views/components/button/base.blade.php
@@ -1,6 +1,12 @@
 @props(['loader' => false, 'tag'])
+
+@php
+    $tag = $attributes->hasAny('href', ':href', 'v-bind:href') ? 'a' : 'button';
+    $tag = $attributes->has('for') ? 'label' : $tag;
+@endphp
+
 <x-rapidez::tag
-    is="{{ $tag ?? ($attributes->has('href') || $attributes->has('v-bind:href') ? 'a' : 'button') }}"
+    :is="$tag"
     {{ $attributes->class([
         'relative inline-block self-start text-center text-sm transition cursor-pointer',
         'disabled:cursor-not-allowed disabled:opacity-70',

--- a/resources/views/components/card/address.blade.php
+++ b/resources/views/components/card/address.blade.php
@@ -3,12 +3,13 @@
 @php
     $attributes = $attributes->merge([
         'v-bind:disabled' => var_export($disabled, true),
-        'v-bind:check' => var_export($check, true),
     ]);
 @endphp
+
 <x-rapidez-ct::card.white
     {{ $attributes->only('v-if') }}
     v-bind:class="{!! $attributes['v-bind:disabled'] !!} ? '!bg-ct-disabled !text-ct-inactive' : ''"
+    :$check
 >
     <x-rapidez-ct::address :$attributes :$customTitle>
         {{ $slot }}


### PR DESCRIPTION
- The query was missed in the upgrade to 3.x
- The button has one use case in confira where it becomes a label. Took the same code from the core
- The payment step needs a gap between payment methods