### PR TITLE
[3.x] Check for label in select input

### DIFF
--- a/resources/views/components/input/select.blade.php
+++ b/resources/views/components/input/select.blade.php
@@ -1,8 +1,10 @@
 @props(['label' => false])
 <label {{ $attributes->only(['v-if', 'v-else', 'v-else-if', 'class'])->class('relative flex flex-col gap-y-1.5 sm:gap-y-2 text-sm line-clamp-1') }}>
-    <x-rapidez-ct::input.label :required="$attributes->get('required')">
-        @lang($label)
-    </x-rapidez-ct::input.label>
+    @if ($label)
+        <x-rapidez-ct::input.label :required="$attributes->get('required')">
+            @lang($label)
+        </x-rapidez-ct::input.label>
+    @endif
     <select {{ $attributes
         ->except(['v-if', 'v-else', 'v-else-if', 'class'])
         ->class('cursor-pointer border-ct-border py-4 px-5 text-sm focus:border-ct-primary font-medium rounded border bg-white outline-none !ring-0 transition-all disabled:bg-ct-inactive-100') }}>


### PR DESCRIPTION
We check for it [in the other inputs](https://github.com/rapidez/checkout-theme/blob/master/resources/views/components/input/index.blade.php), so we should check here as well. Otherwise you may get an empty label with a star in it if the input is required, for example.