### PR TITLE
[3.x] Don't use setExisting query on custom address fields

### DIFF
--- a/resources/views/checkout/partials/sections/address.blade.php
+++ b/resources/views/checkout/partials/sections/address.blade.php
@@ -13,7 +13,6 @@
                 country_code: cart.shipping_addresses[0]?.country.code || window.address_defaults.country_code
             }"
             group="shipping"
-            :before-request="(query, variables, options) => [variables.customer_address_id ? config.queries.setExistingShippingAddressesOnCart : query, variables, options]"
             :callback="updateCart"
             :error-callback="checkResponseForExpiredCart"
             :watch="false"
@@ -34,7 +33,6 @@
                 same_as_shipping: !cart.is_virtual && (cart?.billing_address?.same_as_shipping ?? true),
                 country_code: cart.billing_address?.country.code || window.address_defaults.country_code
             }))"
-            :before-request="(query, variables, options) => [variables.customer_address_id ? config.queries.setExistingBillingAddressOnCart : query, variables, options]"
             :callback="updateCart"
             :error-callback="checkResponseForExpiredCart"
             :watch="false"


### PR DESCRIPTION
The `setExisting` query only sets the `customer_address_id`. This works fine in the core due to the way it combines the customer address select box and the address fields.

However, this line should not have been copied over into the checkout theme, as this now causes a bug where you cannot change an address with a `customer_address_id` in the checkout because it will use the wrong query and not actually care about anything you set in the address form