### PR TITLE
[3.x] Add config option for newsletter visibility

### DIFF
--- a/config/rapidez/checkout-theme.php
+++ b/config/rapidez/checkout-theme.php
@@ -21,15 +21,29 @@ return [
                 'subheading' => 'Logout from your account',
             ],
         ],
+
+        // Show the newsletter signup prompt in the account center
+        'newsletter' => true,
     ],
     'checkout' => [
+        'credentials' => [
+            // Show the newsletter signup prompt on the credentials page
+            'newsletter' => true,
+        ],
+        
         'success' => [
-            // Show the account registration on the success page?
-            'register' => false
+            // Show the account registration on the success page
+            'register' => false,
+
+            // Show the newsletter signup prompt on the success page
+            'newsletter' => true,
         ],
     ],
     'register' => [
-        // Make the user create an address during registration.
+        // Make the user create an address during registration
         'create-address' => false,
+
+        // Show the newsletter signup prompt during registration
+        'newsletter' => true,
     ],
 ];

--- a/resources/views/account/edit.blade.php
+++ b/resources/views/account/edit.blade.php
@@ -11,9 +11,11 @@
                 <x-rapidez-ct::card.inactive>
                     @include('rapidez-ct::account.partials.sections.edit.addresses')
                 </x-rapidez-ct::card.inactive>
-                <x-rapidez-ct::card.inactive>
-                    @include('rapidez-ct::account.partials.sections.edit.newsletter')
-                </x-rapidez-ct::card.inactive>
+                @if (config('rapidez.checkout-theme.account.newsletter'))
+                    <x-rapidez-ct::card.inactive>
+                        @include('rapidez-ct::account.partials.sections.edit.newsletter')
+                    </x-rapidez-ct::card.inactive>
+                @endif
                 <x-rapidez-ct::card.inactive>
                     @include('rapidez-ct::account.partials.sections.edit.email')
                 </x-rapidez-ct::card.inactive>

--- a/resources/views/account/partials/register-account.blade.php
+++ b/resources/views/account/partials/register-account.blade.php
@@ -97,9 +97,11 @@
                 </x-rapidez-ct::card.inactive>
             @endif
 
-            <x-rapidez-ct::card.inactive>
-                <x-rapidez-ct::newsletter v-model="variables.is_subscribed"/>
-            </x-rapidez-ct::card.inactive>
+            @if (config('rapidez.checkout-theme.register.newsletter'))
+                <x-rapidez-ct::card.inactive>
+                    <x-rapidez-ct::newsletter v-model="variables.is_subscribed"/>
+                </x-rapidez-ct::card.inactive>
+            @endif
         </x-rapidez-ct::sections>
     </graphql-mutation>
 </graphql-mutation>

--- a/resources/views/checkout/steps/credentials.blade.php
+++ b/resources/views/checkout/steps/credentials.blade.php
@@ -7,9 +7,11 @@
     <x-rapidez-ct::card.inactive>
         @include('rapidez-ct::checkout.partials.sections.address')
     </x-rapidez-ct::card.inactive>
-    <x-rapidez-ct::card.inactive>
-        @include('rapidez-ct::checkout.partials.sections.newsletter')
-    </x-rapidez-ct::card.inactive>
+    @if (config('rapidez.checkout-theme.checkout.credentials.newsletter'))
+        <x-rapidez-ct::card.inactive>
+            @include('rapidez-ct::checkout.partials.sections.newsletter')
+        </x-rapidez-ct::card.inactive>
+    @endif
     <x-rapidez-ct::card.inactive>
         @include('rapidez-ct::checkout.partials.sections.shipping')
     </x-rapidez-ct::card.inactive>

--- a/resources/views/checkout/steps/success.blade.php
+++ b/resources/views/checkout/steps/success.blade.php
@@ -19,9 +19,11 @@
 
                 @include('rapidez-ct::checkout.partials.sections.success.products')
 
-                <x-rapidez-ct::card.inactive>
-                    @include('rapidez-ct::checkout.partials.sections.success.newsletter')
-                </x-rapidez-ct::card.inactive>  
+                @if (config('rapidez.checkout-theme.checkout.success.newsletter'))
+                    <x-rapidez-ct::card.inactive>
+                        @include('rapidez-ct::checkout.partials.sections.success.newsletter')
+                    </x-rapidez-ct::card.inactive>
+                @endif
                 <x-rapidez-ct::card.inactive>
                     @if (config('rapidez.checkout-theme.checkout.success.register'))
                         @include('rapidez-ct::checkout.partials.sections.success.create-account')


### PR DESCRIPTION
Previously the only way to get rid of the newsletter was to overwrite the templates. Plenty of sites will not have a newsletter or may have some more specific wishes about it, so it should be possible more easily to fine tune this.

As such, I've made every individual location of the newsletter configurable through the config file.