### PR TITLE
[3.x] Instantly disable the place order button

### DIFF
--- a/resources/views/checkout/steps/payment_method.blade.php
+++ b/resources/views/checkout/steps/payment_method.blade.php
@@ -20,7 +20,13 @@
         v-slot="{ mutate, variables }"
     >
         <fieldset>
-            <x-rapidez::button.conversion class="relative" type="submit" dusk="continue" loader>
+            <x-rapidez::button.conversion
+                class="relative"
+                type="submit"
+                dusk="continue"
+                loader
+                v-on:click="(event) => event.target.disabled = true"
+            >
                 @lang('Place order')
             </x-rapidez::button.conversion>
         </fieldset>


### PR DESCRIPTION
Right now it is possible to accidentally place 2 orders from one cart, either because they have a broken mouse or they accidentally click twice. There appears to be a race condition where it's actually possible to bypass the check magento does to try and make sure you can't do this.

This PR instantly disables the button so that it is impossible for this to happen (at least, by accident). Previously, this disabled state was based on the `$root.loading` variable which is not instant, as its value is waiting for a watcher and the async fetching functions.

I made sure to check and this addition does *not* break reactivity with the default disabled state. In other words, if the order placing fails, the button will stop being disabled again like it should.