### PR TITLE
Sort country-select on name

### DIFF
--- a/resources/views/components/input/country-select.blade.php
+++ b/resources/views/components/input/country-select.blade.php
@@ -2,7 +2,7 @@
 <graphql query="{ countries { two_letter_abbreviation full_name_locale } }" cache="countries">
     <template v-if="data" slot-scope="{ data }">
         <x-rapidez-ct::input.select :$label {{ $attributes }}>
-            <option v-for="country in data.countries" :value="country.two_letter_abbreviation.toUpperCase()">
+            <option v-for="country in data.countries.sort((a, b) => a.full_name_locale.localeCompare(b.full_name_locale))" :value="country.two_letter_abbreviation.toUpperCase()">
                 @{{ country.full_name_locale }}
             </option>
         </x-rapidez-ct::input.select>


### PR DESCRIPTION
Right now the country select is not sorted on the text the user see on the frontend but on the value of the `<option>`
![Scherm­afbeelding 2025-02-06 om 16 06 17](https://github.com/user-attachments/assets/3875847f-fc13-4838-af6a-2635b68173ae)

With this changes it sort based on the name the user see on the frontend: 
![Scherm­afbeelding 2025-02-06 om 16 16 20](https://github.com/user-attachments/assets/0972c040-a3c3-4c49-9aaa-86e1b8625155)
![Scherm­afbeelding 2025-02-06 om 16 17 39](https://github.com/user-attachments/assets/e1235a5b-3f79-47fc-a8be-937702501705)
