### PR TITLE
Make use of core version 3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^8.0",
         "blade-ui-kit/blade-heroicons": "^2.0",
         "rapidez/account": "^3.0",
-        "rapidez/core": "^3.1"
+        "rapidez/core": "^3.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Confira requires version 3.5.0 for the change here:https://github.com/rapidez/confira/pull/35. 