### PR TITLE
[2.x] Option to make password optional when account exists

### DIFF
--- a/resources/views/checkout/partials/sections/login/logged-out.blade.php
+++ b/resources/views/checkout/partials/sections/login/logged-out.blade.php
@@ -18,16 +18,18 @@
         label="Password"
         ref="password"
         v-on:input="loginInputChange"
-        required
+        :required="!config('rapidez.frontend.allow_guest_on_existing_account')"
     />
 
-    <input
-        type="checkbox"
-        v-if="!emailAvailable"
-        oninvalid="this.setCustomValidity('{{ __('Please log in') }}')"
-        class="absolute h-full inset-0 opacity-0 pointer-events-none"
-        required
-    />
+    @unless (config('rapidez.frontend.allow_guest_on_existing_account'))
+        <input
+            type="checkbox"
+            v-if="!emailAvailable"
+            oninvalid="this.setCustomValidity('{{ __('Please log in') }}')"
+            class="absolute h-full inset-0 opacity-0 pointer-events-none"
+            required
+        />
+    @endunless
 </div>
 
 <p v-if="!emailAvailable" class="self-end text-ct-inactive">


### PR DESCRIPTION
See https://github.com/rapidez/core/pull/924

Doesn't require a version constraint like this because the value will be `null` on older versions which is falsy.