### PR TITLE
[4.x] Remove unnecessary repeat code from core & fix data reset bug

### DIFF
--- a/resources/core-overwrites/checkout/partials/address.blade.php
+++ b/resources/core-overwrites/checkout/partials/address.blade.php
@@ -1,0 +1,1 @@
+@include('rapidez-ct::checkout.partials.shipping-billing-fields')

--- a/resources/js/components/CheckoutAddress.vue
+++ b/resources/js/components/CheckoutAddress.vue
@@ -13,6 +13,8 @@
         methods: {
             toggleEdit() {
                 this.editing = !this.editing
+                this.$root.$emit('setShippingAddressOnCart')
+                this.$root.$emit('setBillingAddressOnCart')
             },
         },
 

--- a/resources/views/checkout/partials/sections/address.blade.php
+++ b/resources/views/checkout/partials/sections/address.blade.php
@@ -6,49 +6,9 @@
         </div>
     </template>
     <template v-else>
-        <div>
-            <graphql-mutation
-                :query="config.queries.setNewShippingAddressesOnCart"
-                :variables="{
-                    cart_id: mask,
-                    ...window.address_defaults,
-                    ...cart.shipping_addresses[0],
-                    country_code: cart.shipping_addresses[0]?.country.code || window.address_defaults.country_code,
-                    region_id: cart.shipping_addresses[0]?.region.region_id || window.address_defaults.region_id,
-                }"
-                group="shipping"
-                :callback="updateCart"
-                :error-callback="checkResponseForExpiredCart"
-                :watch="false"
-                mutate-event="setShippingAddressesOnCart"
-                v-slot="{ mutate, variables }"
-                v-if="!cart.is_virtual"
-            >
-                <fieldset partial-submit="mutate" v-on:change="function (e) {e.target.closest('fieldset').querySelector(':invalid') === null && mutate().then(() => (cart?.billing_address?.same_as_shipping ?? true) && window.app.$emit('setBillingAddressOnCart'))}">
-                    @include('rapidez-ct::checkout.partials.shipping-billing-fields', ['type' => 'shipping'])
-                </fieldset>
-            </graphql-mutation>
-            <graphql-mutation
-                :query="config.queries.setNewBillingAddressOnCart"
-                :variables="JSON.parse(JSON.stringify({
-                    cart_id: mask,
-                    ...window.address_defaults,
-                    ...cart.billing_address,
-                    same_as_shipping: !cart.is_virtual && (cart?.billing_address?.same_as_shipping ?? true),
-                    country_code: cart.billing_address?.country.code || window.address_defaults.country_code,
-                    region_id: cart.billing_address?.region.region_id || window.address_defaults.region_id,
-                }))"
-                :callback="updateCart"
-                :error-callback="checkResponseForExpiredCart"
-                :watch="false"
-                group="billing"
-                mutate-event="setBillingAddressOnCart"
-                v-slot="{ mutate, variables }"
-            >
-                <fieldset partial-submit="mutate" v-on:change="function (e) {e.target.closest('fieldset').querySelector(':invalid') === null && mutate().then(() => (cart?.billing_address?.same_as_shipping ?? true) && window.app.$emit('setBillingAddressOnCart'))}">
-                    @include('rapidez-ct::checkout.partials.shipping-billing-fields', ['type' => 'billing'])
-                </fieldset>
-            </graphql-mutation>
+        <div class="flex flex-col gap-6">
+            @include('rapidez::checkout.steps.shipping_address')
+            @include('rapidez::checkout.steps.billing_address')
         </div>
     </template>
 </checkout-address>

--- a/resources/views/checkout/partials/shipping-billing-fields.blade.php
+++ b/resources/views/checkout/partials/shipping-billing-fields.blade.php
@@ -8,15 +8,4 @@
     </p>
 @endif
 
-
-<template @if($type == 'billing') v-if="!variables.same_as_shipping" @endif >
-    <x-rapidez-ct::address-form :$type/>
-</template>
-
-@if ($type == 'billing')
-    <div class="mt-5" v-if="!cart.is_virtual">
-        <x-rapidez::input.checkbox v-model="variables.same_as_shipping">
-            @lang('My billing and shipping address are the same')
-        </x-rapidez::input.checkbox>
-    </div>
-@endif
+<x-rapidez-ct::address-form :$type/>


### PR DESCRIPTION
There have been small fixes within the core functionality here that were not carried over into here. For example, the `v-on:change` in the billing fieldset was wrong which caused some errors.

By simplifying and using the core files for this, we can make sure it stays the same functionality-wise.

This also adds an emit on when you toggle edit, because there was a small bug causing field data to reset after the first change. This fixes that as well.