### PR TITLE
Improve resetpassword flow

### DIFF
--- a/resources/views/account/partials/resetpassword.blade.php
+++ b/resources/views/account/partials/resetpassword.blade.php
@@ -4,9 +4,10 @@
     :variables="{ token: '{{ request()->token }}' }"
     :clear="true"
     :notify="{ message: '@lang('Your password has been changed, please login.')' }"
+    redirect="{{ route('account.login') }}"
 >
     <form class="flex flex-col gap-y-5" v-on:submit.prevent="mutate" slot-scope="{ mutate, variables }">
-        <label>
+        <label class="hidden">
             <x-rapidez::label>@lang('Security token')</x-rapidez::label>
             <x-rapidez::input
                 name="token"

--- a/resources/views/account/partials/resetpassword.blade.php
+++ b/resources/views/account/partials/resetpassword.blade.php
@@ -1,7 +1,7 @@
 <graphql-mutation
     v-cloak
     query="mutation reset($email: String!, $token: String!, $password: String!) { resetPassword ( email: $email, resetPasswordToken: $token, newPassword: $password ) }"
-    :variables="{ token: '{{ request()->token }}' }"
+    :variables="{ token: '{{ request()->token }}', email: '{{ request()->email ?? null }}' }"
     :clear="true"
     :notify="{ message: '@lang('Your password has been changed, please login.')' }"
     redirect="{{ route('account.login') }}"

--- a/resources/views/account/partials/resetpassword.blade.php
+++ b/resources/views/account/partials/resetpassword.blade.php
@@ -1,7 +1,7 @@
 <graphql-mutation
     v-cloak
     query="mutation reset($email: String!, $token: String!, $password: String!) { resetPassword ( email: $email, resetPasswordToken: $token, newPassword: $password ) }"
-    :variables="{ token: '{{ request()->token }}', email: '{{ request()->email ?? null }}' }"
+    :variables="{ token: '{{ request()->token }}', email: '{{ request()->email }}' }"
     :clear="true"
     :notify="{ message: '@lang('Your password has been changed, please login.')' }"
     redirect="{{ route('account.login') }}"


### PR DESCRIPTION
Hide the `Security token` field in the form. 
Redirect to the login page when the user succesfully resetted the password.