### PR TITLE
[2.x] Get checkout agreements from database

### DIFF
--- a/resources/views/checkout/partials/sections/payment.blade.php
+++ b/resources/views/checkout/partials/sections/payment.blade.php
@@ -1,28 +1,49 @@
+@php($checkoutAgreements = \Rapidez\Core\Models\CheckoutAgreement::all())
+
 <form id="payment" class="flex flex-col gap-2" v-on:submit.prevent="save(['payment_method'], 4)">
     <div v-for="(method, index) in checkout.payment_methods">
         @include('rapidez-ct::checkout.partials.sections.payment.payment-methods')
     </div>
-    <graphql query="{ checkoutAgreements { agreement_id name checkbox_text content is_html mode } }">
-        <div v-if="data?.checkoutAgreements?.length" class="mt-5 flex flex-col gap-y-4" slot-scope="{ data }">
-            <div v-for="agreement in data.checkoutAgreements">
-                <label
-                    class="text-ct-primary cursor-pointer text-sm underline"
-                    v-bind:for="agreement.checkbox_text"
-                    v-if="agreement.mode == 'AUTO'"
-                >
-                    @{{ agreement.checkbox_text }}
-                </label>
-                <template v-else>
-                    @include('rapidez-ct::checkout.partials.sections.payment.agreement-checkbox')
-                </template>
-                <x-rapidez-ct::slideover id="agreement.checkbox_text">
+    
+    @if (count($checkoutAgreements))
+        <div>
+            @foreach ($checkoutAgreements as $agreement)
+                <x-rapidez::slideover position="right" id="{{ $agreement->agreement_id }}_agreement">
                     <x-slot name="title">
-                        @{{ agreement.name }}
+                        {{ $agreement->name }}
                     </x-slot>
-                    <div v-if="agreement.is_html" v-html="agreement.content"></div>
-                    <div v-else class="whitespace-pre-wrap" v-text="agreement.content"></div>
-                </x-rapidez-ct::slideover>
-            </div>
+
+                    @if ($agreement->is_html)
+                        <div>
+                            {!! $agreement->content !!}
+                        </div>
+                    @else
+                        <div class="whitespace-pre-line">
+                            {{ $agreement->content }}
+                        </div>
+                    @endif
+                </x-rapidez::slideover>
+
+                @if ($agreement->mode == 'AUTO')
+                    <label class="text-gray-700 cursor-pointer underline hover:no-underline" for="{{ $agreement->agreement_id }}_agreement">
+                        {{ $agreement->checkbox_text }}
+                    </label>
+                @else
+                    <div>
+                        <x-rapidez::checkbox
+                            name="agreement_ids[]"
+                            :value="$agreement->agreement_id"
+                            v-model="checkout.agreement_ids"
+                            dusk="agreements"
+                            required
+                        >
+                            <label class="text-gray-700 cursor-pointer underline hover:no-underline" for="{{ $agreement->agreement_id }}_agreement">
+                                {{ $agreement->checkbox_text }}
+                            </label>
+                        </x-rapidez::checkbox>
+                    </div>
+                @endif
+            @endforeach
         </div>
-    </graphql>
+    @endif
 </form>


### PR DESCRIPTION
We already did this in the core, but not in here.

This also works around a Magento 2.4.8-p2 bug (we think, at least) where checkout agreements were grabbed from the customer's registration store rather than the active store.