### PR TITLE
[5.x] Prevent automatic logout on implicit submission

### DIFF
--- a/resources/views/checkout/partials/sections/login/logged-in.blade.php
+++ b/resources/views/checkout/partials/sections/login/logged-in.blade.php
@@ -15,7 +15,7 @@
     <span class="text-muted text-sm">
         @lang('Is this not your account?')
         <user v-slot="user">
-            <button class="underline" v-on:click.prevent="user.logout('/login')" data-testid="logout-button">@lang('Log out')</button>
+            <button class="underline" type="button" v-on:click.prevent="user.logout('/login')" data-testid="logout-button">@lang('Log out')</button>
         </user>
         @lang('and use a different e-mail address.')
     </span>


### PR DESCRIPTION
Because buttons default to `type="submit"` and this was always the first button in the form, this button got automatically pressed whenever the form gets implicitly submitted (e.g. pressing enter in an input). That's just how the html spec works, don't ask me why.